### PR TITLE
harden auth boundaries and tidy duplication

### DIFF
--- a/backend/src/middleware/requireAdmin.ts
+++ b/backend/src/middleware/requireAdmin.ts
@@ -34,3 +34,41 @@ export async function isAdmin(userId: string): Promise<boolean> {
     .maybeSingle();
   return !!data;
 }
+
+/**
+ * Resolves a row by primary key on `table`, then enforces caller-is-owner or
+ * caller-is-admin. Writes the appropriate error response and returns null on
+ * failure; returns the row on success. Routes call this once at the top of
+ * the handler instead of repeating the fetch + isOwner + isAdmin dance.
+ */
+export async function resolveOwnerOrAdmin<T extends { user_id: string }>(
+  table: string,
+  id: string | number,
+  req: Request,
+  res: Response,
+  selectColumns = '*',
+): Promise<T | null> {
+  const { data, error } = await supabase
+    .from(table)
+    .select(selectColumns)
+    .eq('id', id)
+    .maybeSingle();
+
+  if (error) {
+    res.status(500).json({ error: error.message });
+    return null;
+  }
+  if (!data) {
+    res.status(404).json({ error: 'Not found' });
+    return null;
+  }
+
+  const row = data as unknown as T;
+  const isOwner = row.user_id === req.user!.id;
+  if (!isOwner && !(await isAdmin(req.user!.id))) {
+    res.status(403).json({ error: 'Forbidden' });
+    return null;
+  }
+
+  return row;
+}

--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -23,8 +23,8 @@ router.use(requireAdmin);
  */
 router.get('/registrations', async (req: Request, res: Response) => {
   try {
-    const limit = Math.min(parseInt(req.query.limit as string) || 50, 200);
-    const offset = parseInt(req.query.offset as string) || 0;
+    const limit = Math.min(Math.max(parseInt(req.query.limit as string) || 50, 1), 200);
+    const offset = Math.max(parseInt(req.query.offset as string) || 0, 0);
     const status = req.query.status as string | undefined;
 
     let query = supabase

--- a/backend/src/routes/participants.ts
+++ b/backend/src/routes/participants.ts
@@ -8,7 +8,7 @@ import {
   UpdateParticipantSchema,
 } from '../types/participant';
 import { validate } from '../middleware/validate';
-import { isAdmin } from '../middleware/requireAdmin';
+import { isAdmin, resolveOwnerOrAdmin } from '../middleware/requireAdmin';
 
 const router = Router();
 
@@ -141,33 +141,13 @@ router.delete(
   validate({ params: ParticipantParamsSchema }),
   async (req: Request, res: Response) => {
     try {
-      const { id } = req.params;
-
-      const { data: existing, error: fetchError } = await supabase
-        .from('participants')
-        .select('user_id')
-        .eq('id', id)
-        .maybeSingle();
-
-      if (fetchError) {
-        res.status(500).json({ error: fetchError.message });
-        return;
-      }
-      if (!existing) {
-        res.status(404).json({ error: 'Participant not found' });
-        return;
-      }
-
-      const isOwner = existing.user_id === req.user!.id;
-      if (!isOwner && !(await isAdmin(req.user!.id))) {
-        res.status(403).json({ error: 'Forbidden' });
-        return;
-      }
+      const owned = await resolveOwnerOrAdmin('participants', req.params.id, req, res, 'user_id');
+      if (!owned) return;
 
       const { error } = await supabase
         .from('participants')
         .delete()
-        .eq('id', id);
+        .eq('id', req.params.id);
 
       if (error) {
         res.status(500).json({ error: error.message });

--- a/backend/src/routes/registrations.ts
+++ b/backend/src/routes/registrations.ts
@@ -8,7 +8,7 @@ import {
   RegistrationParamsSchema,
 } from '../types/registration';
 import { validate } from '../middleware/validate';
-import { isAdmin } from '../middleware/requireAdmin';
+import { isAdmin, resolveOwnerOrAdmin } from '../middleware/requireAdmin';
 import { sendRegistrationConfirmation } from '../utils/email';
 
 const router = Router();
@@ -157,7 +157,9 @@ router.post(
         return;
       }
 
-      const payload = { ...req.body, user_id: req.user!.id };
+      // email is bound to the authenticated account, not the request body, so
+      // a user can't direct the confirmation email elsewhere.
+      const payload = { ...req.body, user_id: req.user!.id, email: req.user!.email };
 
       const { data, error } = await supabase
         .from('registrations')
@@ -219,30 +221,9 @@ router.get(
   validate({ params: RegistrationParamsSchema }),
   async (req: Request, res: Response) => {
     try {
-      const { id } = req.params;
-
-      const { data, error } = await supabase
-        .from('registrations')
-        .select('*')
-        .eq('id', id)
-        .maybeSingle();
-
-      if (error) {
-        res.status(500).json({ error: error.message });
-        return;
-      }
-      if (!data) {
-        res.status(404).json({ error: 'Registration not found' });
-        return;
-      }
-
-      const isOwner = data.user_id === req.user!.id;
-      if (!isOwner && !(await isAdmin(req.user!.id))) {
-        res.status(403).json({ error: 'Forbidden' });
-        return;
-      }
-
-      res.json(data);
+      const row = await resolveOwnerOrAdmin('registrations', req.params.id, req, res);
+      if (!row) return;
+      res.json(row);
     } catch (err) {
       res.status(500).json({ error: 'Internal server error' });
     }
@@ -258,33 +239,13 @@ router.put(
   validate({ params: RegistrationParamsSchema, body: UpdateRegistrationSchema }),
   async (req: Request<{ id: string }, {}, UpdateRegistrationBody>, res: Response) => {
     try {
-      const { id } = req.params;
-
-      const { data: existing, error: fetchError } = await supabase
-        .from('registrations')
-        .select('user_id')
-        .eq('id', id)
-        .maybeSingle();
-
-      if (fetchError) {
-        res.status(500).json({ error: fetchError.message });
-        return;
-      }
-      if (!existing) {
-        res.status(404).json({ error: 'Registration not found' });
-        return;
-      }
-
-      const isOwner = existing.user_id === req.user!.id;
-      if (!isOwner && !(await isAdmin(req.user!.id))) {
-        res.status(403).json({ error: 'Forbidden' });
-        return;
-      }
+      const owned = await resolveOwnerOrAdmin('registrations', req.params.id, req, res, 'user_id');
+      if (!owned) return;
 
       const { data, error } = await supabase
         .from('registrations')
         .update(req.body)
-        .eq('id', id)
+        .eq('id', req.params.id)
         .select()
         .single();
 
@@ -309,33 +270,13 @@ router.delete(
   validate({ params: RegistrationParamsSchema }),
   async (req: Request, res: Response) => {
     try {
-      const { id } = req.params;
-
-      const { data: existing, error: fetchError } = await supabase
-        .from('registrations')
-        .select('user_id')
-        .eq('id', id)
-        .maybeSingle();
-
-      if (fetchError) {
-        res.status(500).json({ error: fetchError.message });
-        return;
-      }
-      if (!existing) {
-        res.status(404).json({ error: 'Registration not found' });
-        return;
-      }
-
-      const isOwner = existing.user_id === req.user!.id;
-      if (!isOwner && !(await isAdmin(req.user!.id))) {
-        res.status(403).json({ error: 'Forbidden' });
-        return;
-      }
+      const owned = await resolveOwnerOrAdmin('registrations', req.params.id, req, res, 'user_id');
+      if (!owned) return;
 
       const { error } = await supabase
         .from('registrations')
         .delete()
-        .eq('id', id);
+        .eq('id', req.params.id);
 
       if (error) {
         res.status(500).json({ error: error.message });

--- a/backend/src/routes/teams.ts
+++ b/backend/src/routes/teams.ts
@@ -11,9 +11,12 @@ import {
 } from '../types/userTeam';
 import { TeamMatcher } from '../utils/teamMatcher';
 import { validate } from '../middleware/validate';
-import { isAdmin } from '../middleware/requireAdmin';
+import { requireAdmin } from '../middleware/requireAdmin';
 
 const router = Router();
+const adminRouter = Router();
+
+const MAX_TEAM_SIZE = 4;
 
 // ─── User-managed team routes ──────────────────────────────────────────────
 
@@ -191,6 +194,20 @@ router.post(
         return;
       }
 
+      const { count, error: countError } = await supabase
+        .from('user_team_members')
+        .select('*', { count: 'exact', head: true })
+        .eq('team_id', team.id);
+
+      if (countError) {
+        res.status(500).json({ error: countError.message });
+        return;
+      }
+      if ((count ?? 0) >= MAX_TEAM_SIZE) {
+        res.status(409).json({ error: `Team is full (max ${MAX_TEAM_SIZE} members).` });
+        return;
+      }
+
       const { error } = await supabase
         .from('user_team_members')
         .insert({ team_id: team.id, user_id: req.user!.id });
@@ -260,18 +277,18 @@ router.post('/leave', async (req: Request, res: Response) => {
 });
 
 // ─── Admin-only team-matcher routes ────────────────────────────────────────
+// Mounted on a sub-router with requireAdmin so the guard is declared once
+// rather than repeated in every handler.
+
+router.use(adminRouter);
+adminRouter.use(requireAdmin);
 
 /**
  * GET /api/teams
  * Admin-only: runs the team matcher for a pool (does not save).
  */
-router.get('/', async (req: Request, res: Response) => {
+adminRouter.get('/', async (req: Request, res: Response) => {
   try {
-    if (!(await isAdmin(req.user!.id))) {
-      res.status(403).json({ error: 'Admin access required' });
-      return;
-    }
-
     const poolId = (req.query.pool_id as string) || 'default';
     const teamSize = parseInt(req.query.team_size as string) || 4;
 
@@ -312,16 +329,11 @@ router.get('/', async (req: Request, res: Response) => {
  * POST /api/teams/save
  * Admin-only: persists generated teams (replaces any existing teams in the pool).
  */
-router.post(
+adminRouter.post(
   '/save',
   validate({ body: SaveTeamsSchema }),
   async (req: Request<{}, {}, SaveTeamsBody>, res: Response) => {
     try {
-      if (!(await isAdmin(req.user!.id))) {
-        res.status(403).json({ error: 'Admin access required' });
-        return;
-      }
-
       const { pool_id, teams } = req.body;
 
       const { error: deleteError } = await supabase
@@ -334,23 +346,29 @@ router.post(
         return;
       }
 
-      for (const team of teams) {
-        const { data: teamData, error: teamError } = await supabase
-          .from('teams')
-          .insert({ team_number: team.team_number, pool_id })
-          .select()
-          .single();
+      // Two bulk inserts beat one-team-at-a-time: O(2) round-trips instead of
+      // O(2N), so saving 25 teams of 4 stops being 50 sequential DB calls.
+      const { data: insertedTeams, error: teamsError } = await supabase
+        .from('teams')
+        .insert(teams.map((t) => ({ team_number: t.team_number, pool_id })))
+        .select('id, team_number');
 
-        if (teamError) {
-          res.status(500).json({ error: teamError.message });
-          return;
-        }
+      if (teamsError) {
+        res.status(500).json({ error: teamsError.message });
+        return;
+      }
 
-        const memberRows = team.members.map((m) => ({
-          team_id: teamData.id,
+      const teamIdByNumber = new Map(
+        (insertedTeams ?? []).map((t) => [t.team_number, t.id]),
+      );
+      const memberRows = teams.flatMap((t) =>
+        t.members.map((m) => ({
+          team_id: teamIdByNumber.get(t.team_number),
           participant_id: m.participant_id,
-        }));
+        })),
+      );
 
+      if (memberRows.length > 0) {
         const { error: membersError } = await supabase
           .from('team_members')
           .insert(memberRows);
@@ -372,13 +390,8 @@ router.post(
  * GET /api/teams/saved
  * Admin-only: retrieves saved matcher teams with members for a pool.
  */
-router.get('/saved', async (req: Request, res: Response) => {
+adminRouter.get('/saved', async (req: Request, res: Response) => {
   try {
-    if (!(await isAdmin(req.user!.id))) {
-      res.status(403).json({ error: 'Admin access required' });
-      return;
-    }
-
     const poolId = (req.query.pool_id as string) || 'default';
 
     const { data, error } = await supabase

--- a/backend/src/types/participant.ts
+++ b/backend/src/types/participant.ts
@@ -23,10 +23,9 @@ export const CreateParticipantSchema = z.object({
   pool_id: z.string().default('default'),
 });
 
-export const UpdateParticipantSchema = CreateParticipantSchema.partial().refine(
-  (d) => Object.keys(d).length > 0,
-  { message: 'At least one field is required' },
-);
+export const UpdateParticipantSchema = CreateParticipantSchema.omit({ pool_id: true })
+  .partial()
+  .refine((d) => Object.keys(d).length > 0, { message: 'At least one field is required' });
 
 export const ParticipantParamsSchema = z.object({
   id: z.string().uuid('id must be a valid UUID'),

--- a/backend/src/types/registration.ts
+++ b/backend/src/types/registration.ts
@@ -30,7 +30,6 @@ export const CreateRegistrationSchema = z.object({
     .string()
     .trim()
     .regex(/^\(\d{3}\) \d{3}-\d{4}$/, 'phone_number must use format (XXX) XXX-XXXX'),
-  email: z.string().email('email must be a valid email address'),
   linkedin: z.string().url('linkedin must be a valid URL').optional().or(z.literal('')),
   school: z.string().trim().min(1, 'school is required'),
   country: z.string().trim().min(1, 'country is required'),
@@ -63,6 +62,7 @@ export const ResumePathSchema = z.object({
 
 export interface Registration extends CreateRegistrationBody {
   id: string;
+  email: string;
   created_at: string;
 }
 

--- a/frontend/src/components/registration/ApplicationPanel.tsx
+++ b/frontend/src/components/registration/ApplicationPanel.tsx
@@ -53,11 +53,10 @@ async function uploadResume(file: File): Promise<void> {
     body: JSON.stringify({ filename: file.name }),
   });
   if (!urlRes.ok) throw new Error("Could not get upload URL");
-  const { signedUrl, path, token } = await urlRes.json();
+  const { signedUrl, path } = await urlRes.json();
 
-  // Supabase returns either a signedUrl (full URL) or a token; prefer the URL.
-  const target = signedUrl || `${path}?token=${token}`;
-  const putRes = await fetch(target, {
+  if (!signedUrl) throw new Error("Storage upload URL missing");
+  const putRes = await fetch(signedUrl, {
     method: "PUT",
     headers: { "Content-Type": file.type || "application/pdf" },
     body: file,

--- a/frontend/src/components/team-matching/HasTeamView.tsx
+++ b/frontend/src/components/team-matching/HasTeamView.tsx
@@ -10,7 +10,7 @@ interface TeamMember {
 }
 
 interface HasTeamViewProps {
-  teamNumber: number;
+  teamName: string;
   teamCode: string;
   members: TeamMember[];
   onLeaveTeam: () => void;
@@ -18,7 +18,7 @@ interface HasTeamViewProps {
 
 const greyBears = [bearGrey1, bearGrey2, bearGrey3];
 
-export default function HasTeamView({ teamNumber, teamCode, members, onLeaveTeam }: HasTeamViewProps) {
+export default function HasTeamView({ teamName, teamCode, members, onLeaveTeam }: HasTeamViewProps) {
   // Fill remaining spots with grey bears (team of 4, minus "you")
   const maxTeammates = 3;
 
@@ -33,7 +33,7 @@ export default function HasTeamView({ teamNumber, teamCode, members, onLeaveTeam
       <div className="bg-[#fbebe9] flex flex-col items-center px-5 py-10 rounded-lg w-full">
         {/* Team header */}
         <div className="flex items-center justify-between w-full mb-6">
-          <p className="text-xl font-normal text-black">Team {teamNumber}</p>
+          <p className="text-xl font-normal text-black">{teamName}</p>
           <div className="flex items-center gap-3">
             <span className="text-base text-black">Team Code:</span>
             <span className="border border-[#cb4643] rounded-lg px-4 py-2 text-base font-medium text-black">

--- a/frontend/src/lib/buildSchema.ts
+++ b/frontend/src/lib/buildSchema.ts
@@ -49,7 +49,12 @@ export function buildSchemaFromFields(fields: FormField[]): z.ZodType {
         break;
 
       default:
-        s = z.unknown();
+        // FormField.type is statically exhaustive, but the data arrives over
+        // the network and may not match the TypeScript union — fail loudly
+        // rather than silently accept anything.
+        throw new Error(
+          `buildSchemaFromFields: unsupported field type "${(field as { type: string }).type}"`,
+        );
     }
 
     shape[field.id] = s;

--- a/frontend/src/lib/useAdmin.ts
+++ b/frontend/src/lib/useAdmin.ts
@@ -5,10 +5,15 @@ import { supabase } from "@/config/supabase";
 interface AdminState {
   loading: boolean;
   isAdmin: boolean;
+  // True when the admin check could not complete (network error, 5xx). Lets
+  // callers distinguish "confirmed non-admin" from "we don't know yet"
+  // instead of silently kicking real admins out of the panel on transient
+  // failures.
+  error: boolean;
 }
 
 export function useAdmin(): AdminState {
-  const [state, setState] = useState<AdminState>({ loading: true, isAdmin: false });
+  const [state, setState] = useState<AdminState>({ loading: true, isAdmin: false, error: false });
 
   useEffect(() => {
     let cancelled = false;
@@ -16,20 +21,24 @@ export function useAdmin(): AdminState {
     const check = async () => {
       const { data } = await supabase.auth.getSession();
       if (!data.session) {
-        if (!cancelled) setState({ loading: false, isAdmin: false });
+        if (!cancelled) setState({ loading: false, isAdmin: false, error: false });
         return;
       }
       try {
         const res = await apiFetch("/api/admin/me");
         if (cancelled) return;
+        if (res.status === 401 || res.status === 403) {
+          setState({ loading: false, isAdmin: false, error: false });
+          return;
+        }
         if (!res.ok) {
-          setState({ loading: false, isAdmin: false });
+          setState({ loading: false, isAdmin: false, error: true });
           return;
         }
         const body = await res.json();
-        setState({ loading: false, isAdmin: !!body.admin });
+        setState({ loading: false, isAdmin: !!body.admin, error: false });
       } catch {
-        if (!cancelled) setState({ loading: false, isAdmin: false });
+        if (!cancelled) setState({ loading: false, isAdmin: false, error: true });
       }
     };
 

--- a/frontend/src/pages/TeamPage.tsx
+++ b/frontend/src/pages/TeamPage.tsx
@@ -51,8 +51,15 @@ export default function TeamPage() {
   };
 
   useEffect(() => {
-    supabase.auth.getUser().then(({ data }) => setCurrentUserId(data.user?.id ?? null));
-    refreshTeam().catch(() => setView("no-team"));
+    // Resolve the current user before refreshing the team so the teammate
+    // filter (which excludes the current user) doesn't briefly show the user
+    // as their own teammate on slow networks.
+    supabase.auth
+      .getUser()
+      .then(({ data }) => setCurrentUserId(data.user?.id ?? null))
+      .finally(() => {
+        refreshTeam().catch(() => setView("no-team"));
+      });
   }, []);
 
   const handleJoinTeam = async (code: string) => {
@@ -189,7 +196,7 @@ export default function TeamPage() {
         if (!team) return null;
         return (
           <HasTeamView
-            teamNumber={1}
+            teamName={team.name}
             teamCode={team.invite_code}
             members={team.members
               .filter((m) => m.user_id !== currentUserId)

--- a/frontend/src/pages/admin/AdminPage.tsx
+++ b/frontend/src/pages/admin/AdminPage.tsx
@@ -17,7 +17,7 @@ const TABS: { id: Tab; label: string }[] = [
 ];
 
 export default function AdminPage() {
-  const { loading, isAdmin } = useAdmin();
+  const { loading, isAdmin, error } = useAdmin();
   const [tab, setTab] = useState<Tab>("users");
   const [editingKey, setEditingKey] = useState<string | null>(null);
 
@@ -25,6 +25,24 @@ export default function AdminPage() {
     return (
       <RegistrationLayout>
         <p className="font-poppins text-red6">Loading…</p>
+      </RegistrationLayout>
+    );
+  }
+
+  if (error) {
+    // Don't redirect on transient failures — that would silently kick real
+    // admins out of the panel on a 5xx or network blip.
+    return (
+      <RegistrationLayout>
+        <div className="flex flex-col gap-3 px-2 py-2">
+          <p className="font-poppins text-red6">Couldn't verify admin access.</p>
+          <button
+            onClick={() => window.location.reload()}
+            className="self-start px-4 py-2 bg-red5 hover:bg-red3 text-white text-sm font-poppins font-semibold rounded-lg transition-colors"
+          >
+            Retry
+          </button>
+        </div>
       </RegistrationLayout>
     );
   }

--- a/frontend/src/pages/registration/dashboard.tsx
+++ b/frontend/src/pages/registration/dashboard.tsx
@@ -8,7 +8,9 @@ import { apiFetch } from "../../lib/api";
 import arcade from "@/assets/arcade_device2.png";
 import siteBanner from "@/assets/site_banner.png";
 
-const EVENT_DATE = new Date("2026-10-02T09:00:00");
+// 9:00 AM Eastern (UTC-4 during EDT) on Oct 2, 2026 — every viewer counts down
+// to the same instant regardless of their local timezone.
+const EVENT_DATE = new Date("2026-10-02T09:00:00-04:00");
 
 function useCountdown(target: Date) {
   const calc = () => {

--- a/frontend/src/pages/registration/profile.tsx
+++ b/frontend/src/pages/registration/profile.tsx
@@ -33,8 +33,6 @@ interface FormData {
   linkedin: string;
 }
 
-const STORAGE_KEY = "brh_profile";
-
 const inputCls =
   "w-full bg-white border border-gray-200 rounded-lg px-3 py-2.5 text-sm text-gray-800 placeholder-gray-400 focus:outline-none focus:border-red5 transition-colors font-poppins";
 const selectCls =
@@ -86,26 +84,12 @@ const Profile = () => {
   const [saving, setSaving] = useState(false);
   const [errors, setErrors] = useState<Partial<Record<keyof FormData, string>>>({});
 
-  // Load from server first; fall back to localStorage cache if the request fails.
   useEffect(() => {
     let cancelled = false;
 
-    const loadFromCache = () => {
-      const stored = localStorage.getItem(STORAGE_KEY);
-      if (stored) {
-        try {
-          const parsed = JSON.parse(stored);
-          if (!cancelled) setForm((prev) => ({ ...prev, ...parsed }));
-        } catch { /* ignore */ }
-      }
-    };
-
     apiFetch("/api/profile")
       .then(async (res) => {
-        if (!res.ok) {
-          loadFromCache();
-          return;
-        }
+        if (!res.ok) return;
         const profile = await res.json();
         if (cancelled) return;
         setForm((prev) => ({
@@ -128,7 +112,7 @@ const Profile = () => {
           linkedin: profile.linkedin ?? prev.linkedin,
         }));
       })
-      .catch(() => loadFromCache());
+      .catch(() => { /* leave defaults — server is the source of truth */ });
 
     supabase.auth.getUser().then(({ data }) => {
       if (cancelled) return;


### PR DESCRIPTION
## Summary

Fixes from a code review of the recent admin/server-driven-form/team-self-service work.

### Correctness
- **registrations**: bind `email` to the auth account on create and forbid updating it on PUT — a user can no longer redirect their confirmation email or alter their identity post-submit
- **participants**: omit `pool_id` from the partial update schema — users can no longer move themselves into another pool
- **admin**: clamp negative `limit`/`offset` so Supabase doesn't reject the request
- **dashboard**: anchor countdown to Eastern (`-04:00`) instead of local time
- **teams**: enforce `MAX_TEAM_SIZE` on `POST /join`
- **TeamPage**: resolve `currentUserId` before refreshing the team so the user doesn't briefly appear as their own teammate
- **buildSchema**: throw on unknown field types instead of silently accepting anything
- **useAdmin**: add an `error` state so transient failures show a retry instead of redirecting real admins out
- **ApplicationPanel**: drop the broken `signedUrl` fallback that built a relative URL

### Cleanups
- Extract `resolveOwnerOrAdmin` helper; collapse the fetch+isOwner+isAdmin copy-paste in `registrations` GET/PUT/DELETE `/:id` and `participants` DELETE `/:id`
- Move admin matcher routes onto a sub-router guarded by `requireAdmin` middleware
- Replace `teams /save` per-team for-loop with two bulk inserts
- Remove dead localStorage cache from profile page
- `HasTeamView` renders the real team name instead of a hardcoded "Team 1"

## Test plan
- [ ] backend `tsc --noEmit` clean
- [ ] frontend `tsc --noEmit` clean
- [ ] manual: submit a registration with a body `email` differing from the auth email — confirmation email goes to the auth email
- [ ] manual: try `PUT /participants/me` with `pool_id: 'foo'` — request is rejected by validation
- [ ] manual: visit dashboard from a non-Eastern timezone — countdown matches Eastern wall clock
- [ ] manual: 5th user trying `POST /teams/join` on a full team — gets 409

🤖 Generated with [Claude Code](https://claude.com/claude-code)