### PR TITLE
feat: add dynamic application and team matching parity

### DIFF
--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -3,8 +3,18 @@ import { z } from 'zod';
 import { supabase } from '../config/supabase';
 import { isAdmin, requireAdmin } from '../middleware/requireAdmin';
 import { validate } from '../middleware/validate';
+import { RegistrationStatusSchema } from '../types/registration';
 
 const router = Router();
+
+function escapeCsvValue(value: unknown): string {
+  if (value === null || value === undefined) return '';
+  if (Array.isArray(value)) return `"${value.join('; ').replace(/"/g, '""')}"`;
+  const stringValue = String(value);
+  return /[",\n]/.test(stringValue)
+    ? `"${stringValue.replace(/"/g, '""')}"`
+    : stringValue;
+}
 
 /**
  * GET /api/admin/me
@@ -26,6 +36,8 @@ router.get('/registrations', async (req: Request, res: Response) => {
     const limit = Math.min(Math.max(parseInt(req.query.limit as string) || 50, 1), 200);
     const offset = Math.max(parseInt(req.query.offset as string) || 0, 0);
     const status = req.query.status as string | undefined;
+    const search = (req.query.q as string | undefined)?.trim();
+    const formKey = (req.query.form_key as string | undefined)?.trim();
 
     let query = supabase
       .from('registrations')
@@ -34,6 +46,13 @@ router.get('/registrations', async (req: Request, res: Response) => {
       .range(offset, offset + limit - 1);
 
     if (status) query = query.eq('status', status);
+    if (formKey) query = query.eq('form_key', formKey);
+    if (search) {
+      const escaped = search.replace(/,/g, ' ');
+      query = query.or(
+        `first_name.ilike.%${escaped}%,last_name.ilike.%${escaped}%,email.ilike.%${escaped}%,school.ilike.%${escaped}%,major.ilike.%${escaped}%`,
+      );
+    }
 
     const { data, error, count } = await query;
 
@@ -72,17 +91,34 @@ router.get('/registrations/export.csv', async (_req: Request, res: Response) => 
       return;
     }
 
-    const columns = Object.keys(rows[0]);
-    const escape = (v: unknown): string => {
-      if (v === null || v === undefined) return '';
-      if (Array.isArray(v)) return `"${v.join('; ').replace(/"/g, '""')}"`;
-      const s = String(v);
-      return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
-    };
+    const answerKeys = [...new Set(
+      rows.flatMap((row) => {
+        const answers = (row as Record<string, unknown>).answers;
+        return answers && typeof answers === 'object' && !Array.isArray(answers)
+          ? Object.keys(answers as Record<string, unknown>)
+          : [];
+      }),
+    )].sort();
 
+    const baseColumns = Object.keys(rows[0]).filter((column) => column !== 'answers');
+    const columns = [...baseColumns, ...answerKeys.map((key) => `answer:${key}`)];
     const lines = [
       columns.join(','),
-      ...rows.map((row) => columns.map((c) => escape((row as Record<string, unknown>)[c])).join(',')),
+      ...rows.map((row) => {
+        const record = row as Record<string, unknown>;
+        const answers =
+          record.answers && typeof record.answers === 'object' && !Array.isArray(record.answers)
+            ? (record.answers as Record<string, unknown>)
+            : {};
+
+        return columns.map((column) => {
+          if (column.startsWith('answer:')) {
+            return escapeCsvValue(answers[column.slice('answer:'.length)]);
+          }
+
+          return escapeCsvValue(record[column]);
+        }).join(',');
+      }),
     ];
 
     res.setHeader('Content-Type', 'text/csv');
@@ -94,7 +130,7 @@ router.get('/registrations/export.csv', async (_req: Request, res: Response) => 
 });
 
 const DecisionSchema = z.object({
-  status: z.enum(['submitted', 'approved', 'rejected', 'waitlisted']),
+  status: RegistrationStatusSchema,
 });
 const RegistrationIdSchema = z.object({
   id: z.coerce.number().int().positive(),
@@ -129,6 +165,70 @@ router.post(
       res.status(500).json({ error: 'Internal server error' });
     }
   }
+);
+
+router.get(
+  '/registrations/:id/resume-download-url',
+  validate({ params: RegistrationIdSchema }),
+  async (req: Request, res: Response) => {
+    try {
+      const { data, error } = await supabase
+        .from('registrations')
+        .select('resume_path')
+        .eq('id', req.params.id)
+        .maybeSingle();
+
+      if (error) {
+        res.status(500).json({ error: error.message });
+        return;
+      }
+      if (!data?.resume_path) {
+        res.status(404).json({ error: 'No resume uploaded' });
+        return;
+      }
+
+      const { data: signed, error: signedError } = await supabase
+        .storage
+        .from('resumes')
+        .createSignedUrl(data.resume_path, 60 * 5);
+
+      if (signedError) {
+        res.status(500).json({ error: signedError.message });
+        return;
+      }
+
+      res.json(signed);
+    } catch (err) {
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  },
+);
+
+router.get(
+  '/registrations/:id',
+  validate({ params: RegistrationIdSchema }),
+  async (req: Request, res: Response) => {
+    try {
+      const { data, error } = await supabase
+        .from('registrations')
+        .select('*')
+        .eq('id', req.params.id)
+        .maybeSingle();
+
+      if (error) {
+        res.status(500).json({ error: error.message });
+        return;
+      }
+      if (!data) {
+        res.status(404).json({ error: 'Registration not found' });
+        return;
+      }
+
+      res.json(data);
+    } catch (err) {
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  },
 );
 
 // ─── Form configs ──────────────────────────────────────────────────────────

--- a/backend/src/routes/registrations.ts
+++ b/backend/src/routes/registrations.ts
@@ -1,17 +1,145 @@
 import { Router, Request, Response } from 'express';
 import { supabase } from '../config/supabase';
 import {
-  CreateRegistrationBody,
-  UpdateRegistrationBody,
-  CreateRegistrationSchema,
-  UpdateRegistrationSchema,
   RegistrationParamsSchema,
 } from '../types/registration';
 import { validate } from '../middleware/validate';
 import { isAdmin, resolveOwnerOrAdmin } from '../middleware/requireAdmin';
 import { sendRegistrationConfirmation } from '../utils/email';
+import {
+  buildAnswersSchema,
+  projectRegistrationColumns,
+  type DynamicFormField,
+} from '../utils/registrationForms';
 
 const router = Router();
+
+type RegistrationRow = {
+  id: number | string;
+  user_id: string;
+  email: string | null;
+  form_key?: string | null;
+  form_version?: number | null;
+  answers?: Record<string, unknown> | null;
+  resume_path?: string | null;
+  status?: string | null;
+  first_name?: string | null;
+  last_name?: string | null;
+  age?: string | null;
+  phone_number?: string | null;
+  linkedin?: string | null;
+  school?: string | null;
+  country?: string | null;
+  level_of_study?: string | null;
+  major?: string | null;
+  gender?: string | null;
+  dietary_restrictions?: string[] | null;
+  shirt_size?: string | null;
+  mlh_code_of_conduct?: boolean | null;
+  mlh_data_sharing_consent?: boolean | null;
+  mlh_emails_opt_in?: boolean | null;
+};
+
+type FormConfigRow = {
+  key: string;
+  title: string;
+  version: number;
+  fields: DynamicFormField[];
+};
+
+function getFormKey(req: Request): string {
+  const value = req.query.form_key;
+  return typeof value === 'string' && value.trim() ? value.trim() : 'registration';
+}
+
+async function getUserFormConfig(formKey: string): Promise<FormConfigRow | null> {
+  const { data, error } = await supabase
+    .from('form_configs')
+    .select('key, title, version, fields')
+    .eq('key', formKey)
+    .eq('is_active', true)
+    .maybeSingle();
+
+  if (error) {
+    throw error;
+  }
+
+  return data as FormConfigRow | null;
+}
+
+function legacyAnswersFromRow(row: Partial<RegistrationRow>): Record<string, unknown> {
+  return {
+    first_name: row.first_name ?? '',
+    last_name: row.last_name ?? '',
+    age: row.age ?? '',
+    phone_number: row.phone_number ?? '',
+    email: row.email ?? '',
+    linkedin: row.linkedin ?? '',
+    school: row.school ?? '',
+    country: row.country ?? '',
+    level_of_study: row.level_of_study ?? '',
+    major: row.major ?? '',
+    gender: row.gender ?? '',
+    dietary_restrictions: row.dietary_restrictions ?? [],
+    shirt_size: row.shirt_size ?? '',
+    mlh_code_of_conduct: row.mlh_code_of_conduct ?? false,
+    mlh_data_sharing_consent: row.mlh_data_sharing_consent ?? false,
+    mlh_emails_opt_in: row.mlh_emails_opt_in ?? false,
+  };
+}
+
+function toRegistrationResponse(row: RegistrationRow) {
+  const persistedAnswers =
+    row.answers && typeof row.answers === 'object' && !Array.isArray(row.answers)
+      ? row.answers
+      : {};
+
+  return {
+    ...row,
+    form_key: row.form_key ?? 'registration',
+    form_version: row.form_version ?? 1,
+    answers: {
+      ...legacyAnswersFromRow(row),
+      ...persistedAnswers,
+    },
+  };
+}
+
+async function parseAnswersFromBody(
+  req: Request,
+  formKey: string,
+  rawBody: Record<string, unknown> = req.body ?? {},
+) {
+  const formConfig = await getUserFormConfig(formKey);
+  if (!formConfig) {
+    return {
+      status: 404 as const,
+      body: { error: `Active form "${formKey}" not found` },
+    };
+  }
+
+  const schema = buildAnswersSchema(formConfig.fields);
+  const parsed = schema.safeParse(rawBody);
+
+  if (!parsed.success) {
+    return {
+      status: 400 as const,
+      body: {
+        error: 'Invalid form submission',
+        errors: parsed.error.issues.map((issue) => ({
+          field: String(issue.path[0] ?? 'form'),
+          message: issue.message,
+        })),
+      },
+    };
+  }
+
+  return {
+    status: 200 as const,
+    formConfig,
+    answers: parsed.data,
+  };
+}
 
 /**
  * POST /api/registrations/me/resume-upload-url
@@ -47,6 +175,7 @@ router.post('/me/resume-upload-url', async (req: Request, res: Response) => {
 router.post('/me/resume', async (req: Request, res: Response) => {
   try {
     const resumePath = String(req.body?.resume_path || '');
+    const formKey = getFormKey(req);
     if (!resumePath.startsWith(`${req.user!.id}/`)) {
       res.status(400).json({ error: 'resume_path must be inside the caller\'s folder' });
       return;
@@ -56,6 +185,7 @@ router.post('/me/resume', async (req: Request, res: Response) => {
       .from('registrations')
       .update({ resume_path: resumePath })
       .eq('user_id', req.user!.id)
+      .eq('form_key', formKey)
       .select()
       .single();
 
@@ -76,10 +206,12 @@ router.post('/me/resume', async (req: Request, res: Response) => {
  */
 router.get('/me/resume-download-url', async (req: Request, res: Response) => {
   try {
+    const formKey = getFormKey(req);
     const { data: registration, error: regError } = await supabase
       .from('registrations')
       .select('resume_path')
       .eq('user_id', req.user!.id)
+      .eq('form_key', formKey)
       .maybeSingle();
 
     if (regError) {
@@ -114,10 +246,12 @@ router.get('/me/resume-download-url', async (req: Request, res: Response) => {
  */
 router.get('/me', async (req: Request, res: Response) => {
   try {
+    const formKey = getFormKey(req);
     const { data, error } = await supabase
       .from('registrations')
       .select('*')
       .eq('user_id', req.user!.id)
+      .eq('form_key', formKey)
       .maybeSingle();
 
     if (error) {
@@ -130,7 +264,7 @@ router.get('/me', async (req: Request, res: Response) => {
       return;
     }
 
-    res.json(data);
+    res.json(toRegistrationResponse(data as RegistrationRow));
   } catch (err) {
     res.status(500).json({ error: 'Internal server error' });
   }
@@ -141,49 +275,115 @@ router.get('/me', async (req: Request, res: Response) => {
  * Creates a registration owned by the authenticated user.
  * Returns 409 if the user already has one.
  */
-router.post(
-  '/',
-  validate({ body: CreateRegistrationSchema }),
-  async (req: Request<{}, {}, CreateRegistrationBody>, res: Response) => {
-    try {
-      const { data: existing } = await supabase
-        .from('registrations')
-        .select('id')
-        .eq('user_id', req.user!.id)
-        .maybeSingle();
-
-      if (existing) {
-        res.status(409).json({ error: 'Registration already exists for this user' });
-        return;
-      }
-
-      // email is bound to the authenticated account, not the request body, so
-      // a user can't direct the confirmation email elsewhere.
-      const payload = { ...req.body, user_id: req.user!.id, email: req.user!.email };
-
-      const { data, error } = await supabase
-        .from('registrations')
-        .insert(payload)
-        .select()
-        .single();
-
-      if (error) {
-        res.status(500).json({ error: error.message });
-        return;
-      }
-
-      // Fire-and-forget; never fail submission on email transport error.
-      sendRegistrationConfirmation({
-        to: data.email,
-        firstName: data.first_name,
-      }).catch((e) => console.error('[email] confirmation failed:', e));
-
-      res.status(201).json(data);
-    } catch (err) {
-      res.status(500).json({ error: 'Internal server error' });
+router.post('/', async (req: Request<{}, {}, Record<string, unknown>>, res: Response) => {
+  try {
+    const formKey = getFormKey(req);
+    const parsed = await parseAnswersFromBody(req, formKey);
+    if (parsed.status !== 200) {
+      res.status(parsed.status).json(parsed.body);
+      return;
     }
+
+    const { data: existing } = await supabase
+      .from('registrations')
+      .select('id')
+      .eq('user_id', req.user!.id)
+      .eq('form_key', formKey)
+      .maybeSingle();
+
+    if (existing) {
+      res.status(409).json({ error: 'Registration already exists for this user and form' });
+      return;
+    }
+
+    const projected = projectRegistrationColumns(parsed.answers, req.user!);
+    const payload = {
+      user_id: req.user!.id,
+      form_key: formKey,
+      form_version: parsed.formConfig.version,
+      answers: parsed.answers,
+      status: 'pending',
+      ...projected,
+      email: req.user!.email ?? null,
+    };
+
+    const { data, error } = await supabase
+      .from('registrations')
+      .insert(payload)
+      .select()
+      .single();
+
+    if (error) {
+      res.status(500).json({ error: error.message });
+      return;
+    }
+
+    sendRegistrationConfirmation({
+      to: data.email,
+      firstName: data.first_name,
+    }).catch((e) => console.error('[email] confirmation failed:', e));
+
+    res.status(201).json(toRegistrationResponse(data as RegistrationRow));
+  } catch (err) {
+    res.status(500).json({ error: 'Internal server error' });
   }
-);
+});
+
+/**
+ * PUT /api/registrations/me
+ * Updates the authenticated user's submission for a specific form_key.
+ */
+router.put('/me', async (req: Request<{}, {}, Record<string, unknown>>, res: Response) => {
+  try {
+    const formKey = getFormKey(req);
+    const parsed = await parseAnswersFromBody(req, formKey);
+    if (parsed.status !== 200) {
+      res.status(parsed.status).json(parsed.body);
+      return;
+    }
+
+    const { data: existing, error: fetchError } = await supabase
+      .from('registrations')
+      .select('id, status')
+      .eq('user_id', req.user!.id)
+      .eq('form_key', formKey)
+      .maybeSingle();
+
+    if (fetchError) {
+      res.status(500).json({ error: fetchError.message });
+      return;
+    }
+    if (!existing) {
+      res.status(404).json({ error: 'No registration found' });
+      return;
+    }
+
+    const projected = projectRegistrationColumns(parsed.answers, req.user!);
+    const updates = {
+      answers: parsed.answers,
+      form_version: parsed.formConfig.version,
+      ...projected,
+      email: req.user!.email ?? null,
+      status: existing.status ?? 'pending',
+    };
+
+    const { data, error } = await supabase
+      .from('registrations')
+      .update(updates)
+      .eq('id', existing.id)
+      .select()
+      .single();
+
+    if (error) {
+      res.status(500).json({ error: error.message });
+      return;
+    }
+
+    res.json(toRegistrationResponse(data as RegistrationRow));
+  } catch (err) {
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
 
 /**
  * GET /api/registrations
@@ -223,7 +423,7 @@ router.get(
     try {
       const row = await resolveOwnerOrAdmin('registrations', req.params.id, req, res);
       if (!row) return;
-      res.json(row);
+      res.json(toRegistrationResponse(row as RegistrationRow));
     } catch (err) {
       res.status(500).json({ error: 'Internal server error' });
     }
@@ -236,15 +436,47 @@ router.get(
  */
 router.put(
   '/:id',
-  validate({ params: RegistrationParamsSchema, body: UpdateRegistrationSchema }),
-  async (req: Request<{ id: string }, {}, UpdateRegistrationBody>, res: Response) => {
+  validate({ params: RegistrationParamsSchema }),
+  async (req: Request<{ id: string }, {}, Record<string, unknown>>, res: Response) => {
     try {
-      const owned = await resolveOwnerOrAdmin('registrations', req.params.id, req, res, 'user_id');
+      const owned = await resolveOwnerOrAdmin<RegistrationRow>('registrations', req.params.id, req, res);
       if (!owned) return;
+
+      let updates: Record<string, unknown> = { ...req.body };
+
+      if (
+        Object.prototype.hasOwnProperty.call(req.body, 'answers') &&
+        req.body.answers &&
+        typeof req.body.answers === 'object' &&
+        !Array.isArray(req.body.answers)
+      ) {
+        const formKey =
+          typeof owned.form_key === 'string' && owned.form_key.trim()
+            ? owned.form_key
+            : 'registration';
+
+        const parsed = await parseAnswersFromBody(
+          req,
+          formKey,
+          req.body.answers as Record<string, unknown>,
+        );
+        if (parsed.status !== 200) {
+          res.status(parsed.status).json(parsed.body);
+          return;
+        }
+
+        updates = {
+          answers: parsed.answers,
+          form_version: parsed.formConfig.version,
+          ...projectRegistrationColumns(parsed.answers, req.user!),
+        };
+      }
+
+      delete updates.email;
 
       const { data, error } = await supabase
         .from('registrations')
-        .update(req.body)
+        .update(updates)
         .eq('id', req.params.id)
         .select()
         .single();
@@ -254,7 +486,7 @@ router.put(
         return;
       }
 
-      res.json(data);
+      res.json(toRegistrationResponse(data as RegistrationRow));
     } catch (err) {
       res.status(500).json({ error: 'Internal server error' });
     }

--- a/backend/src/routes/teams.ts
+++ b/backend/src/routes/teams.ts
@@ -18,6 +18,58 @@ const adminRouter = Router();
 
 const MAX_TEAM_SIZE = 4;
 
+interface PublishedParticipant {
+  id: string;
+  user_id: string;
+  full_name: string | null;
+}
+
+async function deleteEmptyUserTeams(teamIds: string[]) {
+  if (teamIds.length === 0) return;
+
+  for (const teamId of [...new Set(teamIds)]) {
+    const { count, error } = await supabase
+      .from('user_team_members')
+      .select('*', { count: 'exact', head: true })
+      .eq('team_id', teamId);
+
+    if (error) {
+      throw error;
+    }
+
+    if ((count ?? 0) === 0) {
+      const { error: deleteError } = await supabase
+        .from('user_teams')
+        .delete()
+        .eq('id', teamId);
+
+      if (deleteError) {
+        throw deleteError;
+      }
+    }
+  }
+}
+
+function normalizePublishedParticipant(value: unknown): PublishedParticipant | null {
+  if (Array.isArray(value)) {
+    return normalizePublishedParticipant(value[0]);
+  }
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const participant = value as Record<string, unknown>;
+  if (typeof participant.user_id !== 'string' || participant.user_id.length === 0) {
+    return null;
+  }
+
+  return {
+    id: String(participant.id ?? ''),
+    user_id: participant.user_id,
+    full_name: typeof participant.full_name === 'string' ? participant.full_name : null,
+  };
+}
+
 // ─── User-managed team routes ──────────────────────────────────────────────
 
 /**
@@ -402,7 +454,7 @@ adminRouter.get('/saved', async (req: Request, res: Response) => {
           id,
           participant_id,
           participant:participants (
-            id, email, full_name, hacker_type,
+            id, user_id, email, full_name, hacker_type,
             frontend_experience, backend_experience, design_experience, hardware_experience,
             frontend_preference, backend_preference, design_preference, hardware_preference,
             any_role_preference,
@@ -421,6 +473,147 @@ adminRouter.get('/saved', async (req: Request, res: Response) => {
     res.json(data);
   } catch (err) {
     res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+/**
+ * POST /api/teams/publish
+ * Admin-only: publishes saved matcher teams into the real user team model.
+ */
+adminRouter.post('/publish', async (req: Request, res: Response) => {
+  try {
+    const poolId = String(req.body?.pool_id || req.query.pool_id || 'default');
+
+    const { data: savedTeams, error: savedTeamsError } = await supabase
+      .from('teams')
+      .select(`
+        id,
+        team_number,
+        members:team_members (
+          participant:participants (
+            id,
+            user_id,
+            full_name
+          )
+        )
+      `)
+      .eq('pool_id', poolId)
+      .order('team_number', { ascending: true });
+
+    if (savedTeamsError) {
+      res.status(500).json({ error: savedTeamsError.message });
+      return;
+    }
+    if (!savedTeams || savedTeams.length === 0) {
+      res.status(404).json({ error: 'No saved matcher teams found for this pool' });
+      return;
+    }
+
+    const usersToPublish = savedTeams.flatMap((team) =>
+      (team.members ?? [])
+        .map((member) => normalizePublishedParticipant(member.participant))
+        .filter((participant): participant is PublishedParticipant => participant !== null)
+        .map((participant) => participant.user_id),
+    );
+
+    if (usersToPublish.length === 0) {
+      res.status(400).json({ error: 'Saved teams do not contain publishable user accounts' });
+      return;
+    }
+
+    const { data: existingMemberships, error: existingMembershipsError } = await supabase
+      .from('user_team_members')
+      .select('team_id, user_id')
+      .in('user_id', usersToPublish);
+
+    if (existingMembershipsError) {
+      res.status(500).json({ error: existingMembershipsError.message });
+      return;
+    }
+
+    if ((existingMemberships ?? []).length > 0) {
+      const impactedTeamIds = (existingMemberships ?? []).map((membership) => membership.team_id);
+      const { error: deleteMembershipsError } = await supabase
+        .from('user_team_members')
+        .delete()
+        .in('user_id', usersToPublish);
+
+      if (deleteMembershipsError) {
+        res.status(500).json({ error: deleteMembershipsError.message });
+        return;
+      }
+
+      await deleteEmptyUserTeams(impactedTeamIds);
+    }
+
+    let publishedCount = 0;
+
+    for (const savedTeam of savedTeams) {
+      const members = (savedTeam.members ?? [])
+        .map((member) => normalizePublishedParticipant(member.participant))
+        .filter((participant): participant is PublishedParticipant => participant !== null);
+
+      if (members.length === 0) {
+        continue;
+      }
+
+      let createdTeam: { id: string } | null = null;
+      let lastError: string | null = null;
+
+      for (let attempt = 0; attempt < 5; attempt++) {
+        const inviteCode = generateInviteCode();
+        const { data: teamRow, error: createTeamError } = await supabase
+          .from('user_teams')
+          .insert({
+            name: `${poolId} Match Team ${savedTeam.team_number}`,
+            invite_code: inviteCode,
+            created_by: req.user!.id,
+          })
+          .select('id')
+          .single();
+
+        if (!createTeamError && teamRow) {
+          createdTeam = teamRow;
+          break;
+        }
+
+        lastError = createTeamError?.message ?? 'Failed to create published team';
+        if (!createTeamError?.message?.includes('duplicate')) {
+          break;
+        }
+      }
+
+      if (!createdTeam) {
+        res.status(500).json({ error: lastError ?? 'Failed to create published team' });
+        return;
+      }
+
+      const { error: insertMembersError } = await supabase
+        .from('user_team_members')
+        .insert(
+          members.map((member) => ({
+            team_id: createdTeam!.id,
+            user_id: member.user_id,
+          })),
+        );
+
+      if (insertMembersError) {
+        await supabase.from('user_teams').delete().eq('id', createdTeam.id);
+        res.status(500).json({ error: insertMembersError.message });
+        return;
+      }
+
+      publishedCount += 1;
+    }
+
+    res.status(201).json({
+      message: 'Matcher teams published to user teams',
+      published_teams: publishedCount,
+      affected_users: usersToPublish.length,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Internal server error';
+    res.status(500).json({ error: message });
   }
 });
 

--- a/backend/src/types/registration.ts
+++ b/backend/src/types/registration.ts
@@ -1,70 +1,15 @@
 import { z } from 'zod';
 
-const AGE_RANGES = ['Under 18', '18–20', '21–24', '25–30', '31+'] as const;
-const GENDER_OPTIONS = ['Male', 'Female', 'Non-binary', 'Prefer not to say', 'Other'] as const;
-const DIETARY_OPTIONS = [
-  'None',
-  'Vegetarian',
-  'Vegan',
-  'Gluten-Free',
-  'Halal',
-  'Kosher',
-  'Nut Allergy',
-  'Other',
-] as const;
-const SHIRT_SIZES = ['XS', 'S', 'M', 'L', 'XL', '2XL'] as const;
-const LEVEL_OF_STUDY_OPTIONS = [
-  'Secondary / High School',
-  'Freshman',
-  'Sophomore',
-  'Junior',
-  'Senior',
-  "I'm not currently a student",
-] as const;
-
-export const CreateRegistrationSchema = z.object({
-  first_name: z.string().trim().min(1, 'first_name is required'),
-  last_name: z.string().trim().min(1, 'last_name is required'),
-  age: z.enum(AGE_RANGES, { message: 'age is required' }),
-  phone_number: z
-    .string()
-    .trim()
-    .regex(/^\(\d{3}\) \d{3}-\d{4}$/, 'phone_number must use format (XXX) XXX-XXXX'),
-  linkedin: z.string().url('linkedin must be a valid URL').optional().or(z.literal('')),
-  school: z.string().trim().min(1, 'school is required'),
-  country: z.string().trim().min(1, 'country is required'),
-  level_of_study: z.enum(LEVEL_OF_STUDY_OPTIONS, { message: 'level_of_study is required' }),
-  major: z.string().trim().optional().or(z.literal('')),
-  gender: z.enum(GENDER_OPTIONS, { message: 'gender is required' }),
-  dietary_restrictions: z.array(z.enum(DIETARY_OPTIONS)).default([]),
-  shirt_size: z.enum(SHIRT_SIZES, { message: 'shirt_size is required' }),
-  mlh_code_of_conduct: z.literal(true, {
-    message: 'MLH Code of Conduct agreement is required',
-  }),
-  mlh_data_sharing_consent: z.literal(true, {
-    message: 'MLH data sharing agreement is required',
-  }),
-  mlh_emails_opt_in: z.boolean().optional().default(false),
-});
-
-export const UpdateRegistrationSchema = CreateRegistrationSchema.partial().refine(
-  (data) => Object.keys(data).length > 0,
-  { message: 'At least one field is required' },
-);
-
 export const RegistrationParamsSchema = z.object({
   id: z.coerce.number().int().positive('id must be a positive integer'),
 });
 
-export const ResumePathSchema = z.object({
-  resume_path: z.string().min(1).optional(),
-});
+export const RegistrationStatusSchema = z.enum([
+  'pending',
+  'submitted',
+  'approved',
+  'rejected',
+  'waitlisted',
+]);
 
-export interface Registration extends CreateRegistrationBody {
-  id: string;
-  email: string;
-  created_at: string;
-}
-
-export type CreateRegistrationBody = z.infer<typeof CreateRegistrationSchema>;
-export type UpdateRegistrationBody = z.infer<typeof UpdateRegistrationSchema>;
+export type RegistrationStatus = z.infer<typeof RegistrationStatusSchema>;

--- a/backend/src/utils/registrationForms.test.js
+++ b/backend/src/utils/registrationForms.test.js
@@ -1,0 +1,92 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  buildAnswersSchema,
+  projectRegistrationColumns,
+} = require('./registrationForms');
+
+test('buildAnswersSchema requires every row in a required preference grid', () => {
+  const fields = [
+    {
+      id: 'preferred_role',
+      label: 'Preferred Role',
+      type: 'preferenceGrid',
+      required: true,
+      rows: ['Frontend', 'Backend'],
+      columns: ['1', '2', '3'],
+    },
+  ];
+
+  const schema = buildAnswersSchema(fields);
+  const result = schema.safeParse({
+    preferred_role: {
+      Frontend: '1',
+    },
+  });
+
+  assert.equal(result.success, false);
+  if (result.success) return;
+  assert.match(result.error.issues[0]?.message ?? '', /Backend/);
+});
+
+test('buildAnswersSchema accepts complete answers for supported field types', () => {
+  const fields = [
+    {
+      id: 'first_name',
+      label: 'First Name',
+      type: 'text',
+      required: true,
+    },
+    {
+      id: 'mlh_code_of_conduct',
+      label: 'MLH Code of Conduct',
+      type: 'checkbox',
+      required: true,
+    },
+    {
+      id: 'preferred_role',
+      label: 'Preferred Role',
+      type: 'preferenceGrid',
+      required: true,
+      rows: ['Frontend', 'Backend'],
+      columns: ['1', '2', '3'],
+    },
+  ];
+
+  const schema = buildAnswersSchema(fields);
+  const result = schema.safeParse({
+    first_name: 'Richie',
+    mlh_code_of_conduct: true,
+    preferred_role: {
+      Frontend: '1',
+      Backend: '2',
+    },
+  });
+
+  assert.equal(result.success, true);
+});
+
+test('projectRegistrationColumns derives the admin summary fields from answers', () => {
+  const projected = projectRegistrationColumns(
+    {
+      first_name: 'Richie',
+      last_name: 'Xue',
+      school: 'Cornell University',
+      level_of_study: 'Senior',
+      shirt_size: 'M',
+      email: 'ignored@example.com',
+    },
+    {
+      email: 'actual@cornell.edu',
+    },
+  );
+
+  assert.deepEqual(projected, {
+    first_name: 'Richie',
+    last_name: 'Xue',
+    school: 'Cornell University',
+    level_of_study: 'Senior',
+    shirt_size: 'M',
+    email: 'actual@cornell.edu',
+  });
+});

--- a/backend/src/utils/registrationForms.ts
+++ b/backend/src/utils/registrationForms.ts
@@ -1,0 +1,120 @@
+import { z } from 'zod';
+
+export type DynamicFormFieldType =
+  | 'text'
+  | 'email'
+  | 'dropdown'
+  | 'radio'
+  | 'checkbox'
+  | 'checkboxGroup'
+  | 'file'
+  | 'multipleChoiceGrid'
+  | 'preferenceGrid';
+
+interface BaseDynamicFormField {
+  id: string;
+  label: string;
+  type: DynamicFormFieldType;
+  required: boolean;
+}
+
+export type DynamicFormField =
+  | (BaseDynamicFormField & { type: 'text' | 'email' | 'dropdown' | 'radio' })
+  | (BaseDynamicFormField & { type: 'checkbox' })
+  | (BaseDynamicFormField & { type: 'checkboxGroup' })
+  | (BaseDynamicFormField & { type: 'file' })
+  | (BaseDynamicFormField & {
+      type: 'multipleChoiceGrid' | 'preferenceGrid';
+      rows: string[];
+      columns: string[];
+    });
+
+function buildGridSchema(field: Extract<DynamicFormField, { type: 'multipleChoiceGrid' | 'preferenceGrid' }>) {
+  if (!field.required) {
+    return z.record(z.string(), z.string()).optional();
+  }
+
+  const rowShape = Object.fromEntries(
+    field.rows.map((row) => [
+      row,
+      z
+        .unknown()
+        .refine((value) => typeof value === 'string' && value.trim().length > 0, `${field.label}: ${row} is required`)
+        .refine(
+          (value) => typeof value === 'string' && field.columns.includes(value),
+          `${field.label}: ${row} must be one of the configured options`,
+        ),
+    ]),
+  );
+
+  return z.object(rowShape);
+}
+
+export function buildAnswersSchema(fields: DynamicFormField[]) {
+  const shape: Record<string, z.ZodTypeAny> = {};
+
+  for (const field of fields) {
+    switch (field.type) {
+      case 'text':
+      case 'dropdown':
+      case 'radio':
+        shape[field.id] = field.required
+          ? z.string().trim().min(1, `${field.label} is required`)
+          : z.string().trim().optional().or(z.literal(''));
+        break;
+      case 'email':
+        shape[field.id] = field.required
+          ? z.string().trim().email(`${field.label} must be a valid email`)
+          : z.string().trim().email(`${field.label} must be a valid email`).optional().or(z.literal(''));
+        break;
+      case 'checkbox':
+        shape[field.id] = field.required
+          ? z.literal(true, { message: `${field.label} is required` })
+          : z.boolean().optional();
+        break;
+      case 'checkboxGroup':
+        shape[field.id] = field.required
+          ? z.array(z.string()).min(1, `${field.label} is required`)
+          : z.array(z.string()).optional();
+        break;
+      case 'file':
+        shape[field.id] = z.any().optional();
+        break;
+      case 'multipleChoiceGrid':
+      case 'preferenceGrid':
+        shape[field.id] = buildGridSchema(field);
+        break;
+      default:
+        throw new Error(`Unsupported field type: ${(field as DynamicFormField).type}`);
+    }
+  }
+
+  return z.object(shape);
+}
+
+const SUMMARY_KEYS = [
+  'first_name',
+  'last_name',
+  'school',
+  'level_of_study',
+  'shirt_size',
+] as const;
+
+type SummaryProjection = Record<(typeof SUMMARY_KEYS)[number] | 'email', string | null>;
+
+export function projectRegistrationColumns(
+  answers: Record<string, unknown>,
+  user: { email?: string | null },
+): SummaryProjection {
+  const projection = Object.fromEntries(
+    SUMMARY_KEYS.map((key) => {
+      const value = answers[key];
+      return [key, typeof value === 'string' && value.trim() ? value.trim() : null];
+    }),
+  ) as Omit<SummaryProjection, 'email'>;
+
+  return {
+    ...projection,
+    email: user.email ?? null,
+  };
+}

--- a/frontend/src/components/registration/ApplicationPanel.tsx
+++ b/frontend/src/components/registration/ApplicationPanel.tsx
@@ -11,6 +11,15 @@ interface ApplicationPanelProps {
   onSubmitted: () => void;
 }
 
+interface RegistrationResponse {
+  id: number | string;
+  answers?: Record<string, unknown>;
+  status?: string | null;
+  resume_path?: string | null;
+}
+
+const FORM_KEY = "registration";
+
 interface ServerProfile {
   first_name?: string | null;
   last_name?: string | null;
@@ -46,8 +55,14 @@ function profileToFormValues(profile: ServerProfile): Record<string, unknown> | 
   };
 }
 
-async function uploadResume(file: File): Promise<void> {
-  const urlRes = await apiFetch("/api/registrations/me/resume-upload-url", {
+function registrationToFormValues(registration: RegistrationResponse): Record<string, unknown> {
+  return registration.answers && typeof registration.answers === "object"
+    ? registration.answers
+    : {};
+}
+
+async function uploadResume(file: File): Promise<string> {
+  const urlRes = await apiFetch(`/api/registrations/me/resume-upload-url?form_key=${FORM_KEY}`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ filename: file.name }),
@@ -63,49 +78,108 @@ async function uploadResume(file: File): Promise<void> {
   });
   if (!putRes.ok) throw new Error("Storage upload failed");
 
-  const persistRes = await apiFetch("/api/registrations/me/resume", {
+  const persistRes = await apiFetch(`/api/registrations/me/resume?form_key=${FORM_KEY}`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ resume_path: path }),
   });
   if (!persistRes.ok) throw new Error("Could not save resume reference");
+  return path;
 }
 
 export default function ApplicationPanel({ isOpen, onClose, onSubmitted }: ApplicationPanelProps) {
   const { showToast } = useToast();
   const [isLoading, setIsLoading] = useState(false);
+  const [isBootstrapping, setIsBootstrapping] = useState(false);
   const [isSubmitted, setIsSubmitted] = useState(false);
   const [prefillBannerDismissed, setPrefillBannerDismissed] = useState(false);
   const [initialValues, setInitialValues] = useState<Record<string, unknown>>({});
   const [resumeFile, setResumeFile] = useState<File | null>(null);
+  const [existingResumePath, setExistingResumePath] = useState<string | null>(null);
+  const [hasExistingSubmission, setHasExistingSubmission] = useState(false);
+  const [submissionMode, setSubmissionMode] = useState<"created" | "updated">("created");
   const [config, setConfig] = useState<FormConfig>(hackathonRegistrationFormConfig);
   const [profileValues, setProfileValues] = useState<Record<string, unknown> | null>(null);
 
   useEffect(() => {
-    apiFetch("/api/form-configs/registration")
-      .then(async (res) => {
-        if (!res.ok) return;
-        const remote = await res.json();
-        const fields = remote.fields as FormField[];
-        setConfig({
-          title: remote.title,
-          description: remote.description ?? undefined,
-          schema: buildSchemaFromFields(fields),
-          fields,
-        });
-      })
-      .catch(() => { /* fall back to bundled config */ });
+    if (!isOpen) return;
 
-    apiFetch("/api/profile")
-      .then(async (res) => {
-        if (!res.ok) return;
-        const profile = (await res.json()) as ServerProfile;
-        setProfileValues(profileToFormValues(profile));
-      })
-      .catch(() => { /* leave null — banner won't show */ });
-  }, []);
+    let cancelled = false;
 
-  const showPrefillBanner = profileValues !== null && !prefillBannerDismissed && Object.keys(initialValues).length === 0;
+    const loadPanelState = async () => {
+      setIsBootstrapping(true);
+      setIsSubmitted(false);
+      setResumeFile(null);
+
+      try {
+        const [configRes, profileRes, registrationRes] = await Promise.all([
+          apiFetch(`/api/form-configs/${FORM_KEY}`),
+          apiFetch("/api/profile"),
+          apiFetch(`/api/registrations/me?form_key=${FORM_KEY}`),
+        ]);
+
+        if (!cancelled && configRes.ok) {
+          const remote = await configRes.json();
+          const fields = remote.fields as FormField[];
+          setConfig({
+            title: remote.title,
+            description: remote.description ?? undefined,
+            schema: buildSchemaFromFields(fields),
+            fields,
+          });
+        }
+
+        if (!cancelled && profileRes.ok) {
+          const profile = (await profileRes.json()) as ServerProfile;
+          setProfileValues(profileToFormValues(profile));
+        }
+
+        if (!cancelled && registrationRes.ok) {
+          const registration = (await registrationRes.json()) as RegistrationResponse;
+          setHasExistingSubmission(true);
+          setSubmissionMode("updated");
+          setInitialValues(registrationToFormValues(registration));
+          setExistingResumePath(registration.resume_path ?? null);
+          setPrefillBannerDismissed(true);
+          return;
+        }
+
+        if (!cancelled) {
+          setHasExistingSubmission(false);
+          setSubmissionMode("created");
+          setInitialValues({});
+          setExistingResumePath(null);
+          setPrefillBannerDismissed(false);
+        }
+      } catch {
+        if (!cancelled) {
+          setHasExistingSubmission(false);
+          setSubmissionMode("created");
+          setExistingResumePath(null);
+        }
+      } finally {
+        if (!cancelled) {
+          setIsBootstrapping(false);
+        }
+      }
+    };
+
+    loadPanelState().catch(() => {
+      if (!cancelled) {
+        setIsBootstrapping(false);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen]);
+
+  const showPrefillBanner =
+    !hasExistingSubmission &&
+    profileValues !== null &&
+    !prefillBannerDismissed &&
+    Object.keys(initialValues).length === 0;
 
   const handlePrefillAccept = () => {
     setInitialValues(profileValues!);
@@ -119,30 +193,40 @@ export default function ApplicationPanel({ isOpen, onClose, onSubmitted }: Appli
   const handleSubmit = async (data: Record<string, unknown>) => {
     setIsLoading(true);
     try {
-      const res = await apiFetch("/api/registrations", {
-        method: "POST",
+      const method = hasExistingSubmission ? "PUT" : "POST";
+      const endpoint = hasExistingSubmission
+        ? `/api/registrations/me?form_key=${FORM_KEY}`
+        : `/api/registrations?form_key=${FORM_KEY}`;
+      const res = await apiFetch(endpoint, {
+        method,
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(data),
       });
       if (!res.ok) {
         if (res.status === 409) {
           showToast("You've already submitted an application.", "info");
-          setIsSubmitted(true);
-          onSubmitted();
+          setHasExistingSubmission(true);
           return;
         }
         const err = await res.json();
         throw new Error(err.errors?.[0]?.message || err.error || err.message || "Failed to submit");
       }
 
+      const savedRegistration = (await res.json()) as RegistrationResponse;
+      let nextResumePath = savedRegistration.resume_path ?? existingResumePath;
+
       if (resumeFile) {
         try {
-          await uploadResume(resumeFile);
+          nextResumePath = await uploadResume(resumeFile);
         } catch {
           showToast("Application submitted, but resume upload failed. You can upload it later.", "info");
         }
       }
 
+      setSubmissionMode(hasExistingSubmission ? "updated" : "created");
+      setHasExistingSubmission(true);
+      setExistingResumePath(nextResumePath);
+      setInitialValues(registrationToFormValues(savedRegistration));
       setIsSubmitted(true);
       onSubmitted();
     } catch (error) {
@@ -151,6 +235,22 @@ export default function ApplicationPanel({ isOpen, onClose, onSubmitted }: Appli
     } finally {
       setIsLoading(false);
     }
+  };
+
+  const handleResumeDownload = async () => {
+    const res = await apiFetch(`/api/registrations/me/resume-download-url?form_key=${FORM_KEY}`);
+    if (!res.ok) {
+      showToast("Could not get the uploaded resume.", "error");
+      return;
+    }
+
+    const body = await res.json();
+    if (!body.signedUrl) {
+      showToast("Uploaded resume is unavailable right now.", "error");
+      return;
+    }
+
+    window.open(body.signedUrl, "_blank", "noopener,noreferrer");
   };
 
   return (
@@ -211,12 +311,20 @@ export default function ApplicationPanel({ isOpen, onClose, onSubmitted }: Appli
 
         {/* Form content */}
         <div className="flex-1 overflow-y-auto overscroll-contain px-8 py-6">
-          {isSubmitted ? (
+          {isBootstrapping ? (
+            <div className="flex h-full items-center justify-center">
+              <p className="font-poppins text-sm text-gray-500">Loading application…</p>
+            </div>
+          ) : isSubmitted ? (
             <div className="flex flex-col items-center justify-center h-full gap-4 text-center">
               <p className="text-6xl font-jersey10 text-red5">Done!</p>
-              <h3 className="text-xl font-poppins font-bold text-red6">Application Submitted</h3>
+              <h3 className="text-xl font-poppins font-bold text-red6">
+                {submissionMode === "updated" ? "Application Updated" : "Application Submitted"}
+              </h3>
               <p className="font-poppins text-sm text-gray-500 max-w-xs leading-relaxed">
-                Thanks for applying to Big Red Hacks 2026. We'll review your application and reach out soon.
+                {submissionMode === "updated"
+                  ? "Your application changes have been saved."
+                  : "Thanks for applying to Big Red Hacks 2026. We'll review your application and reach out soon."}
               </p>
               <button
                 onClick={onClose}
@@ -228,18 +336,36 @@ export default function ApplicationPanel({ isOpen, onClose, onSubmitted }: Appli
           ) : (
             <>
               <div className="mb-5 bg-red7 border border-red5/20 rounded-xl px-5 py-4">
-                <label className="font-poppins text-sm font-semibold text-gray-800 block mb-2">
-                  Resume (optional)
-                </label>
-                <input
-                  type="file"
-                  accept=".pdf,.doc,.docx"
-                  onChange={(e) => setResumeFile(e.target.files?.[0] ?? null)}
-                  className="text-sm font-poppins text-gray-700"
-                />
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <label className="font-poppins text-sm font-semibold text-gray-800 block mb-2">
+                      Resume (optional)
+                    </label>
+                    <input
+                      type="file"
+                      accept=".pdf,.doc,.docx"
+                      onChange={(e) => setResumeFile(e.target.files?.[0] ?? null)}
+                      className="text-sm font-poppins text-gray-700"
+                    />
+                  </div>
+                  {existingResumePath && (
+                    <button
+                      type="button"
+                      onClick={handleResumeDownload}
+                      className="shrink-0 rounded-lg border border-red5 px-3 py-2 text-xs font-poppins font-semibold text-red5 transition-colors hover:bg-white"
+                    >
+                      View Uploaded Resume
+                    </button>
+                  )}
+                </div>
                 {resumeFile && (
                   <p className="mt-1 text-xs font-poppins text-gray-500">
                     Selected: {resumeFile.name}
+                  </p>
+                )}
+                {!resumeFile && existingResumePath && (
+                  <p className="mt-1 text-xs font-poppins text-gray-500">
+                    A resume is already on file. Upload a new file to replace it.
                   </p>
                 )}
               </div>

--- a/frontend/src/components/registration/DynamicForm.tsx
+++ b/frontend/src/components/registration/DynamicForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import type { FormConfig, FormField } from "@/lib/formConfig";
 import TextInput from "./form-fields/TextInput";
 import Dropdown from "./form-fields/Dropdown";
@@ -20,6 +20,11 @@ interface DynamicFormProps {
 export default function DynamicForm({ config, onSubmit, isLoading = false, initialValues = {}, hideHeader = false }: DynamicFormProps) {
   const [formData, setFormData] = useState<Record<string, unknown>>(initialValues);
   const [errors, setErrors] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    setFormData(initialValues);
+    setErrors({});
+  }, [initialValues]);
 
   const handleFieldChange = (fieldId: string, value: unknown) => {
     setFormData((prev) => ({

--- a/frontend/src/components/team-matching/MatchingFormView.tsx
+++ b/frontend/src/components/team-matching/MatchingFormView.tsx
@@ -5,9 +5,14 @@ import { teamMatchingFormConfig } from "@/lib/formConfig";
 interface MatchingFormViewProps {
   onBack: () => void;
   onSubmit: (data: Record<string, unknown>) => void;
+  initialValues?: Record<string, unknown>;
 }
 
-export default function MatchingFormView({ onBack, onSubmit }: MatchingFormViewProps) {
+export default function MatchingFormView({
+  onBack,
+  onSubmit,
+  initialValues = {},
+}: MatchingFormViewProps) {
   const [isLoading, setIsLoading] = useState(false);
 
   const handleSubmit = async (data: Record<string, unknown>) => {
@@ -42,6 +47,7 @@ export default function MatchingFormView({ onBack, onSubmit }: MatchingFormViewP
             config={{ ...teamMatchingFormConfig, title: "", description: "" }}
             onSubmit={handleSubmit}
             isLoading={isLoading}
+            initialValues={initialValues}
           />
         </div>
       </div>

--- a/frontend/src/lib/buildSchema.ts
+++ b/frontend/src/lib/buildSchema.ts
@@ -1,6 +1,26 @@
 import { z } from "zod";
 import type { FormField } from "./formConfig";
 
+function buildRequiredGridSchema(field: Extract<FormField, { type: "multipleChoiceGrid" | "preferenceGrid" }>) {
+  const rowShape = Object.fromEntries(
+    field.rows.map((row) => [
+      row,
+      z
+        .unknown()
+        .refine(
+          (value) => typeof value === "string" && value.trim().length > 0,
+          `${field.label}: ${row} is required`,
+        )
+        .refine(
+          (value) => typeof value === "string" && field.columns.includes(value),
+          `${field.label}: ${row} must be one of the configured options`,
+        ),
+    ]),
+  );
+
+  return z.object(rowShape);
+}
+
 /**
  * Build a Zod schema from a list of FormField definitions.
  * Used to validate dynamic, admin-edited form configs at runtime.
@@ -45,7 +65,9 @@ export function buildSchemaFromFields(fields: FormField[]): z.ZodType {
 
       case "multipleChoiceGrid":
       case "preferenceGrid":
-        s = z.record(z.string(), z.unknown()).optional();
+        s = field.required
+          ? buildRequiredGridSchema(field)
+          : z.record(z.string(), z.unknown()).optional();
         break;
 
       default:

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -11,6 +11,7 @@ import Dashboard from "./pages/registration/dashboard";
 import Profile from "./pages/registration/profile";
 import ResetPasswordPage from "./pages/ResetPasswordPage";
 import AdminPage from "./pages/admin/AdminPage";
+import DynamicFormPage from "./pages/DynamicFormPage";
 import { ProtectedRoute } from "./components/ProtectedRoute";
 
 createRoot(document.getElementById("root")!).render(
@@ -28,6 +29,7 @@ createRoot(document.getElementById("root")!).render(
         <Route path="/profile" element={<ProtectedRoute><Profile /></ProtectedRoute>} />
         <Route path="/team" element={<ProtectedRoute><TeamPage /></ProtectedRoute>} />
         <Route path="/admin" element={<ProtectedRoute><AdminPage /></ProtectedRoute>} />
+        <Route path="/forms/:key" element={<ProtectedRoute><DynamicFormPage /></ProtectedRoute>} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
     </BrowserRouter>

--- a/frontend/src/pages/DynamicFormPage.tsx
+++ b/frontend/src/pages/DynamicFormPage.tsx
@@ -1,0 +1,126 @@
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import RegistrationLayout from "@/components/layouts/RegistrationLayout";
+import DynamicForm from "@/components/registration/DynamicForm";
+import { useToast } from "@/components/Toast/ToastContext";
+import { apiFetch } from "@/lib/api";
+import { buildSchemaFromFields } from "@/lib/buildSchema";
+import type { FormConfig, FormField } from "@/lib/formConfig";
+
+interface RegistrationResponse {
+  answers?: Record<string, unknown>;
+}
+
+export default function DynamicFormPage() {
+  const { key = "" } = useParams();
+  const { showToast } = useToast();
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [config, setConfig] = useState<FormConfig | null>(null);
+  const [initialValues, setInitialValues] = useState<Record<string, unknown>>({});
+  const [hasExistingSubmission, setHasExistingSubmission] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      setLoading(true);
+      const [configRes, registrationRes] = await Promise.all([
+        apiFetch(`/api/form-configs/${key}`),
+        apiFetch(`/api/registrations/me?form_key=${encodeURIComponent(key)}`),
+      ]);
+
+      if (!configRes.ok) {
+        if (!cancelled) {
+          showToast("Could not load this form.", "error");
+          setConfig(null);
+          setLoading(false);
+        }
+        return;
+      }
+
+      const remote = await configRes.json();
+      const fields = remote.fields as FormField[];
+
+      if (!cancelled) {
+        setConfig({
+          title: remote.title,
+          description: remote.description ?? undefined,
+          schema: buildSchemaFromFields(fields),
+          fields,
+        });
+      }
+
+      if (registrationRes.ok) {
+        const registration = (await registrationRes.json()) as RegistrationResponse;
+        if (!cancelled) {
+          setInitialValues(registration.answers ?? {});
+          setHasExistingSubmission(true);
+        }
+      } else if (!cancelled) {
+        setInitialValues({});
+        setHasExistingSubmission(false);
+      }
+
+      if (!cancelled) {
+        setLoading(false);
+      }
+    };
+
+    load().catch(() => {
+      if (!cancelled) {
+        showToast("Could not load this form.", "error");
+        setLoading(false);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [key, showToast]);
+
+  const handleSubmit = async (data: Record<string, unknown>) => {
+    setSubmitting(true);
+    const res = await apiFetch(
+      hasExistingSubmission
+        ? `/api/registrations/me?form_key=${encodeURIComponent(key)}`
+        : `/api/registrations?form_key=${encodeURIComponent(key)}`,
+      {
+        method: hasExistingSubmission ? "PUT" : "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+      },
+    );
+    setSubmitting(false);
+
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      showToast(body.error || body.errors?.[0]?.message || "Could not save this form.", "error");
+      return;
+    }
+
+    const registration = (await res.json()) as RegistrationResponse;
+    setInitialValues(registration.answers ?? data);
+    setHasExistingSubmission(true);
+    showToast("Form saved.", "success");
+  };
+
+  return (
+    <RegistrationLayout>
+      <div className="mx-auto max-w-4xl">
+        {loading && <p className="font-poppins text-sm text-gray-500">Loading form…</p>}
+        {!loading && !config && (
+          <p className="font-poppins text-sm text-gray-500">This form is unavailable.</p>
+        )}
+        {!loading && config && (
+          <DynamicForm
+            config={config}
+            onSubmit={handleSubmit}
+            isLoading={submitting}
+            initialValues={initialValues}
+          />
+        )}
+      </div>
+    </RegistrationLayout>
+  );
+}

--- a/frontend/src/pages/TeamPage.tsx
+++ b/frontend/src/pages/TeamPage.tsx
@@ -25,10 +25,54 @@ interface UserTeam {
   members: { user_id: string; full_name: string; joined_at: string }[];
 }
 
+interface ParticipantSubmission {
+  email: string;
+  full_name: string;
+  frontend_experience: string;
+  backend_experience: string;
+  design_experience: string;
+  hardware_experience: string;
+  frontend_preference: number;
+  backend_preference: number;
+  design_preference: number;
+  hardware_preference: number;
+  any_role_preference: number;
+  frontend_skills: string[];
+  backend_skills: string[];
+  design_skills: string[];
+  hacker_type: "FirstTimeHacker" | "VeteranHacker";
+}
+
+function participantToFormValues(participant: ParticipantSubmission): Record<string, unknown> {
+  return {
+    email: participant.email,
+    full_name: participant.full_name,
+    technical_skills: {
+      Frontend: participant.frontend_experience,
+      Backend: participant.backend_experience,
+      Design: participant.design_experience,
+      Hardware: participant.hardware_experience,
+    },
+    preferred_role: {
+      Frontend: String(participant.frontend_preference),
+      Backend: String(participant.backend_preference),
+      Design: String(participant.design_preference),
+      Hardware: String(participant.hardware_preference),
+      Any: String(participant.any_role_preference),
+    },
+    frontend_skills: participant.frontend_skills.join(", "),
+    backend_skills: participant.backend_skills.join(", "),
+    design_skills: participant.design_skills.join(", "),
+    first_time_hacker: participant.hacker_type === "FirstTimeHacker" ? "Yes" : "No",
+  };
+}
+
 export default function TeamPage() {
   const [view, setView] = useState<TeamState>("loading");
   const [team, setTeam] = useState<UserTeam | null>(null);
   const [currentUserId, setCurrentUserId] = useState<string | null>(null);
+  const [matchingInitialValues, setMatchingInitialValues] = useState<Record<string, unknown>>({});
+  const [hasMatchingSubmission, setHasMatchingSubmission] = useState(false);
   const { showToast } = useToast();
 
   const refreshTeam = async () => {
@@ -44,8 +88,13 @@ export default function TeamPage() {
     // No team — check if they've already submitted matching prefs.
     const prefsRes = await apiFetch("/api/participants/me");
     if (prefsRes.ok) {
+      const participant = (await prefsRes.json()) as ParticipantSubmission;
+      setMatchingInitialValues(participantToFormValues(participant));
+      setHasMatchingSubmission(true);
       setView("matching-pending");
     } else {
+      setMatchingInitialValues({});
+      setHasMatchingSubmission(false);
       setView("no-team");
     }
   };
@@ -147,8 +196,8 @@ export default function TeamPage() {
       pool_id: "default",
     };
 
-    const response = await apiFetch("/api/participants", {
-      method: "POST",
+    const response = await apiFetch(hasMatchingSubmission ? "/api/participants/me" : "/api/participants", {
+      method: hasMatchingSubmission ? "PUT" : "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(payload),
     });
@@ -159,6 +208,8 @@ export default function TeamPage() {
     }
 
     showToast("Team matching preferences saved.", "success");
+    setMatchingInitialValues(data);
+    setHasMatchingSubmission(true);
     setView("matching-pending");
   };
 
@@ -183,6 +234,7 @@ export default function TeamPage() {
           <MatchingFormView
             onBack={() => setView("no-team")}
             onSubmit={handleMatchFormSubmit}
+            initialValues={matchingInitialValues}
           />
         );
       case "matching-pending":

--- a/frontend/src/pages/admin/AdminFormEditor.tsx
+++ b/frontend/src/pages/admin/AdminFormEditor.tsx
@@ -20,7 +20,6 @@ const TYPE_OPTIONS: { value: FormFieldType; label: string }[] = [
   { value: "radio", label: "Radio" },
   { value: "checkbox", label: "Single Checkbox" },
   { value: "checkboxGroup", label: "Multi-select" },
-  { value: "file", label: "File Upload" },
   { value: "multipleChoiceGrid", label: "Multiple Choice Grid" },
   { value: "preferenceGrid", label: "Preference Grid" },
 ];

--- a/frontend/src/pages/admin/AdminPage.tsx
+++ b/frontend/src/pages/admin/AdminPage.tsx
@@ -6,14 +6,15 @@ import AdminUsers from "./AdminUsers";
 import AdminStats from "./AdminStats";
 import AdminFormEditor from "./AdminFormEditor";
 import AdminFormList from "./AdminFormList";
+import AdminTeamMatching from "./AdminTeamMatching";
 
-type Tab = "editor" | "stats" | "users" | "settings";
+type Tab = "editor" | "stats" | "users" | "teams";
 
 const TABS: { id: Tab; label: string }[] = [
   { id: "editor", label: "Application Editor" },
   { id: "stats", label: "Stats" },
   { id: "users", label: "Users" },
-  { id: "settings", label: "Settings" },
+  { id: "teams", label: "Team Matching" },
 ];
 
 export default function AdminPage() {
@@ -85,18 +86,9 @@ export default function AdminPage() {
               ? <AdminFormEditor formKey={editingKey} onBack={() => setEditingKey(null)} />
               : <AdminFormList onSelect={setEditingKey} />
           )}
-          {tab === "settings" && <ComingSoon label="Settings" />}
+          {tab === "teams" && <AdminTeamMatching />}
         </div>
       </div>
     </RegistrationLayout>
-  );
-}
-
-function ComingSoon({ label }: { label: string }) {
-  return (
-    <div className="flex flex-col items-center justify-center h-full py-20 gap-2">
-      <p className="text-2xl font-poppins font-semibold text-red6">{label}</p>
-      <p className="text-sm font-poppins text-gray-500">Coming soon.</p>
-    </div>
   );
 }

--- a/frontend/src/pages/admin/AdminTeamMatching.tsx
+++ b/frontend/src/pages/admin/AdminTeamMatching.tsx
@@ -1,0 +1,246 @@
+import { useEffect, useState } from "react";
+import { apiFetch } from "@/lib/api";
+import { useToast } from "@/components/Toast/ToastContext";
+import {
+  buildGenerateDraftErrorState,
+  buildGenerateDraftSuccessState,
+  type MatcherTeam,
+  type ParticipantSummary,
+} from "./adminTeamMatchingState";
+
+interface SavedTeam {
+  id: string;
+  team_number: number;
+  members: {
+    id: string;
+    participant_id: string;
+    participant: ParticipantSummary;
+  }[];
+}
+
+export default function AdminTeamMatching() {
+  const { showToast } = useToast();
+  const [poolId, setPoolId] = useState("default");
+  const [teamSize, setTeamSize] = useState("4");
+  const [participantsCount, setParticipantsCount] = useState<number | null>(null);
+  const [draftTeams, setDraftTeams] = useState<MatcherTeam[]>([]);
+  const [generateError, setGenerateError] = useState<string | null>(null);
+  const [savedTeams, setSavedTeams] = useState<SavedTeam[]>([]);
+  const [loadingSaved, setLoadingSaved] = useState(true);
+  const [running, setRunning] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [publishing, setPublishing] = useState(false);
+
+  const refreshSaved = async () => {
+    setLoadingSaved(true);
+    const res = await apiFetch(`/api/teams/saved?pool_id=${encodeURIComponent(poolId)}`);
+    if (!res.ok) {
+      setSavedTeams([]);
+      setLoadingSaved(false);
+      return;
+    }
+    setSavedTeams(await res.json());
+    setLoadingSaved(false);
+  };
+
+  useEffect(() => {
+    refreshSaved().catch(() => setLoadingSaved(false));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [poolId]);
+
+  const handleGenerate = async () => {
+    setRunning(true);
+    const params = new URLSearchParams({
+      pool_id: poolId,
+      team_size: teamSize,
+    });
+    const res = await apiFetch(`/api/teams?${params.toString()}`);
+    setRunning(false);
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      const nextState = buildGenerateDraftErrorState(
+        body.error || "Could not run the team matcher.",
+      );
+      setParticipantsCount(nextState.participantsCount);
+      setDraftTeams(nextState.draftTeams);
+      setGenerateError(nextState.generateError);
+      showToast(nextState.generateError ?? "Could not run the team matcher.", "error");
+      return;
+    }
+    const body = await res.json();
+    const nextState = buildGenerateDraftSuccessState(body);
+    setParticipantsCount(nextState.participantsCount);
+    setDraftTeams(nextState.draftTeams);
+    setGenerateError(nextState.generateError);
+  };
+
+  const handleSave = async () => {
+    if (draftTeams.length === 0) {
+      showToast("Generate teams before saving them.", "error");
+      return;
+    }
+    setSaving(true);
+    const res = await apiFetch("/api/teams/save", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        pool_id: poolId,
+        teams: draftTeams.map((team) => ({
+          team_number: team.team_number,
+          pool_id: poolId,
+          members: team.members.map((member) => ({ participant_id: member.id })),
+        })),
+      }),
+    });
+    setSaving(false);
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      showToast(body.error || "Could not save matcher teams.", "error");
+      return;
+    }
+    showToast("Saved matcher teams.", "success");
+    await refreshSaved();
+  };
+
+  const handlePublish = async () => {
+    if (savedTeams.length === 0) {
+      showToast("Save teams before publishing them.", "error");
+      return;
+    }
+    setPublishing(true);
+    const res = await apiFetch("/api/teams/publish", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ pool_id: poolId }),
+    });
+    setPublishing(false);
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      showToast(body.error || "Could not publish matcher teams.", "error");
+      return;
+    }
+    const body = await res.json();
+    showToast(
+      `Published ${body.published_teams ?? 0} matcher teams to the real team system.`,
+      "success",
+    );
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="rounded-lg border border-red6/20 bg-white p-5">
+        <div className="flex flex-wrap items-end gap-4">
+          <div>
+            <label className="mb-1 block text-xs font-poppins font-semibold uppercase tracking-widest text-gray-500">
+              Pool ID
+            </label>
+            <input
+              value={poolId}
+              onChange={(e) => setPoolId(e.target.value)}
+              className="rounded-lg border border-gray-200 px-3 py-2 text-sm font-poppins focus:border-red5 focus:outline-none"
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-xs font-poppins font-semibold uppercase tracking-widest text-gray-500">
+              Team Size
+            </label>
+            <input
+              value={teamSize}
+              onChange={(e) => setTeamSize(e.target.value)}
+              className="w-24 rounded-lg border border-gray-200 px-3 py-2 text-sm font-poppins focus:border-red5 focus:outline-none"
+            />
+          </div>
+          <button
+            onClick={handleGenerate}
+            disabled={running}
+            className="rounded-lg bg-red5 px-4 py-2 text-sm font-poppins font-semibold text-white transition-colors hover:bg-red3 disabled:opacity-50"
+          >
+            {running ? "Generating…" : "Generate Draft"}
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={saving || draftTeams.length === 0}
+            className="rounded-lg bg-red5 px-4 py-2 text-sm font-poppins font-semibold text-white transition-colors hover:bg-red3 disabled:opacity-50"
+          >
+            {saving ? "Saving…" : "Save Draft"}
+          </button>
+          <button
+            onClick={handlePublish}
+            disabled={publishing || savedTeams.length === 0}
+            className="rounded-lg border border-red5 px-4 py-2 text-sm font-poppins font-semibold text-red5 transition-colors hover:bg-red5 hover:text-white disabled:opacity-50"
+          >
+            {publishing ? "Publishing…" : "Publish to User Teams"}
+          </button>
+        </div>
+        <p className="mt-3 text-xs font-poppins text-gray-500">
+          Draft teams stay in the matcher tables until you publish them into the real team system used by `/team`.
+        </p>
+        {participantsCount !== null && (
+          <p className="mt-2 text-sm font-poppins text-gray-700">
+            Generated draft for {participantsCount} participants across {draftTeams.length} teams.
+          </p>
+        )}
+        {generateError && (
+          <p className="mt-2 text-sm font-poppins text-red6">
+            {generateError}
+          </p>
+        )}
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <TeamListCard
+          title="Current Draft"
+          emptyLabel="Run the matcher to preview draft teams."
+          teams={draftTeams.map((team) => ({
+            team_number: team.team_number,
+            members: team.members,
+          }))}
+        />
+        <TeamListCard
+          title="Saved Drafts"
+          emptyLabel={loadingSaved ? "Loading saved drafts…" : "No saved drafts for this pool."}
+          teams={savedTeams.map((team) => ({
+            team_number: team.team_number,
+            members: team.members.map((member) => member.participant),
+          }))}
+        />
+      </div>
+    </div>
+  );
+}
+
+function TeamListCard({
+  title,
+  emptyLabel,
+  teams,
+}: {
+  title: string;
+  emptyLabel: string;
+  teams: Array<{ team_number: number; members: ParticipantSummary[] }>;
+}) {
+  return (
+    <div className="rounded-lg border border-red6/20 bg-white p-5">
+      <h2 className="mb-3 text-lg font-poppins font-semibold text-red6">{title}</h2>
+      {teams.length === 0 ? (
+        <p className="text-sm font-poppins text-gray-500">{emptyLabel}</p>
+      ) : (
+        <div className="flex flex-col gap-3">
+          {teams.map((team) => (
+            <div key={team.team_number} className="rounded-lg border border-red6/10 bg-red7/30 px-4 py-3">
+              <p className="text-sm font-poppins font-semibold text-gray-800">
+                Team {team.team_number}
+              </p>
+              <ul className="mt-2 flex flex-col gap-1 text-sm font-poppins text-gray-600">
+                {team.members.map((member) => (
+                  <li key={member.id}>
+                    {member.full_name} · {member.email} · {member.hacker_type}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/AdminUsers.tsx
+++ b/frontend/src/pages/admin/AdminUsers.tsx
@@ -2,24 +2,31 @@ import { useEffect, useMemo, useState } from "react";
 import { apiFetch } from "@/lib/api";
 import { useToast } from "@/components/Toast/ToastContext";
 
-interface Registration {
+interface RegistrationSummary {
   id: number;
   user_id: string;
   created_at: string;
-  first_name: string;
-  last_name: string;
   email: string;
+  first_name?: string | null;
+  last_name?: string | null;
   school?: string | null;
   level_of_study?: string | null;
   major?: string | null;
   shirt_size?: string | null;
   status: string;
   resume_path?: string | null;
+  form_key?: string | null;
+}
+
+interface RegistrationDetail extends RegistrationSummary {
+  answers?: Record<string, unknown>;
+  form_version?: number | null;
 }
 
 const STATUS_OPTIONS = ["pending", "submitted", "approved", "rejected", "waitlisted"] as const;
+const PAGE_SIZE = 50;
 
-const COLUMNS: { key: keyof Registration; label: string; width?: string }[] = [
+const COLUMNS: { key: keyof RegistrationSummary; label: string }[] = [
   { key: "first_name", label: "First Name" },
   { key: "last_name", label: "Last Name" },
   { key: "email", label: "Email" },
@@ -29,42 +36,69 @@ const COLUMNS: { key: keyof Registration; label: string; width?: string }[] = [
   { key: "status", label: "Status" },
 ];
 
+function formatAnswer(value: unknown): string {
+  if (value === null || value === undefined) return "—";
+  if (Array.isArray(value)) return value.length > 0 ? value.join(", ") : "—";
+  if (typeof value === "object") {
+    return Object.entries(value as Record<string, unknown>)
+      .map(([key, inner]) => `${key}: ${formatAnswer(inner)}`)
+      .join(" | ");
+  }
+  if (typeof value === "boolean") return value ? "Yes" : "No";
+  return String(value);
+}
+
 export default function AdminUsers() {
   const { showToast } = useToast();
-  const [rows, setRows] = useState<Registration[]>([]);
+  const [rows, setRows] = useState<RegistrationSummary[]>([]);
   const [loading, setLoading] = useState(true);
+  const [count, setCount] = useState(0);
   const [search, setSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState<string>("");
+  const [page, setPage] = useState(0);
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+  const [detail, setDetail] = useState<RegistrationDetail | null>(null);
+  const [detailLoading, setDetailLoading] = useState(false);
 
   const refresh = async () => {
     setLoading(true);
-    const params = new URLSearchParams({ limit: "200", offset: "0" });
+    const params = new URLSearchParams({
+      limit: String(PAGE_SIZE),
+      offset: String(page * PAGE_SIZE),
+    });
     if (statusFilter) params.set("status", statusFilter);
+    if (search.trim()) params.set("q", search.trim());
+
     const res = await apiFetch(`/api/admin/registrations?${params.toString()}`);
     if (!res.ok) {
       showToast("Failed to load registrations.", "error");
       setLoading(false);
       return;
     }
+
     const body = await res.json();
     setRows(body.data ?? []);
+    setCount(body.count ?? 0);
     setLoading(false);
   };
 
   useEffect(() => {
     refresh().catch(() => setLoading(false));
     // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [statusFilter, page]);
+
+  useEffect(() => {
+    setPage(0);
   }, [statusFilter]);
 
-  const filtered = useMemo(() => {
-    if (!search.trim()) return rows;
-    const q = search.toLowerCase();
-    return rows.filter((r) =>
-      [r.first_name, r.last_name, r.email, r.school, r.major]
-        .filter(Boolean)
-        .some((v) => String(v).toLowerCase().includes(q))
-    );
-  }, [rows, search]);
+  const filteredRows = useMemo(() => rows, [rows]);
+  const totalPages = Math.max(1, Math.ceil(count / PAGE_SIZE));
+
+  const handleSearchSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setPage(0);
+    await refresh();
+  };
 
   const handleStatusChange = async (id: number, status: string) => {
     const res = await apiFetch(`/api/admin/registrations/${id}/decision`, {
@@ -76,7 +110,9 @@ export default function AdminUsers() {
       showToast("Could not update status.", "error");
       return;
     }
-    setRows((prev) => prev.map((r) => (r.id === id ? { ...r, status } : r)));
+
+    setRows((prev) => prev.map((row) => (row.id === id ? { ...row, status } : row)));
+    setDetail((prev) => (prev && prev.id === id ? { ...prev, status } : prev));
   };
 
   const handleExport = async () => {
@@ -96,93 +132,233 @@ export default function AdminUsers() {
     URL.revokeObjectURL(url);
   };
 
+  const loadDetail = async (id: number) => {
+    setSelectedId(id);
+    setDetailLoading(true);
+    const res = await apiFetch(`/api/admin/registrations/${id}`);
+    if (!res.ok) {
+      showToast("Could not load the application details.", "error");
+      setSelectedId(null);
+      setDetailLoading(false);
+      return;
+    }
+    setDetail(await res.json());
+    setDetailLoading(false);
+  };
+
+  const handleResumeDownload = async () => {
+    if (!detail) return;
+    const res = await apiFetch(`/api/admin/registrations/${detail.id}/resume-download-url`);
+    if (!res.ok) {
+      showToast("Resume is unavailable.", "error");
+      return;
+    }
+    const body = await res.json();
+    if (!body.signedUrl) {
+      showToast("Resume is unavailable.", "error");
+      return;
+    }
+    window.open(body.signedUrl, "_blank", "noopener,noreferrer");
+  };
+
+  const detailEntries = detail?.answers
+    ? Object.entries(detail.answers).sort(([left], [right]) => left.localeCompare(right))
+    : [];
+
   return (
     <div className="flex flex-col gap-4">
-      {/* Controls */}
-      <div className="flex items-center gap-3">
-        <button
-          onClick={handleExport}
-          className="px-4 py-2 bg-red5 hover:bg-red3 text-white text-sm font-poppins font-semibold rounded-lg transition-colors"
-        >
-          Export CSV
-        </button>
-        <input
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          placeholder="Search name, email, school…"
-          className="flex-1 bg-white border border-gray-200 rounded-lg px-3 py-2 text-sm font-poppins focus:outline-none focus:border-red5"
-        />
+      <div className="flex items-center justify-between gap-4">
+        <form onSubmit={handleSearchSubmit} className="flex flex-1 items-center gap-3">
+          <input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search name, email, school…"
+            className="flex-1 rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm font-poppins focus:border-red5 focus:outline-none"
+          />
+          <button
+            type="submit"
+            className="rounded-lg bg-red5 px-4 py-2 text-sm font-poppins font-semibold text-white transition-colors hover:bg-red3"
+          >
+            Search
+          </button>
+        </form>
         <select
           value={statusFilter}
           onChange={(e) => setStatusFilter(e.target.value)}
-          className="bg-white border border-gray-200 rounded-lg px-3 py-2 text-sm font-poppins cursor-pointer focus:outline-none focus:border-red5"
+          className="rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm font-poppins focus:border-red5 focus:outline-none"
         >
           <option value="">All statuses</option>
-          {STATUS_OPTIONS.map((s) => (
-            <option key={s} value={s}>{s}</option>
+          {STATUS_OPTIONS.map((status) => (
+            <option key={status} value={status}>
+              {status}
+            </option>
           ))}
         </select>
+        <button
+          onClick={handleExport}
+          className="rounded-lg bg-red5 px-4 py-2 text-sm font-poppins font-semibold text-white transition-colors hover:bg-red3"
+        >
+          Export CSV
+        </button>
       </div>
 
-      {/* Table */}
-      <div className="bg-white border border-red6/20 rounded-lg overflow-hidden">
-        <table className="w-full text-sm font-poppins">
-          <thead className="bg-red7 text-red6">
-            <tr>
-              {COLUMNS.map((c) => (
-                <th key={String(c.key)} className="text-left px-4 py-3 font-semibold">
-                  {c.label}
-                </th>
+      <div className="grid grid-cols-[minmax(0,1fr)_420px] gap-4">
+        <div className="overflow-hidden rounded-lg border border-red6/20 bg-white">
+          <table className="w-full text-sm font-poppins">
+            <thead className="bg-red7 text-red6">
+              <tr>
+                {COLUMNS.map((column) => (
+                  <th key={String(column.key)} className="px-4 py-3 text-left font-semibold">
+                    {column.label}
+                  </th>
+                ))}
+                <th className="px-4 py-3 text-left font-semibold">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {loading && (
+                <tr>
+                  <td colSpan={COLUMNS.length + 1} className="px-4 py-8 text-center text-gray-500">
+                    Loading…
+                  </td>
+                </tr>
+              )}
+              {!loading && filteredRows.length === 0 && (
+                <tr>
+                  <td colSpan={COLUMNS.length + 1} className="px-4 py-8 text-center text-gray-500">
+                    No registrations.
+                  </td>
+                </tr>
+              )}
+              {!loading && filteredRows.map((row) => (
+                <tr
+                  key={row.id}
+                  className={`border-t border-red6/10 hover:bg-red7/40 ${
+                    selectedId === row.id ? "bg-red7/60" : ""
+                  }`}
+                >
+                  {COLUMNS.map((column) => {
+                    const value = row[column.key];
+                    return (
+                      <td key={String(column.key)} className="px-4 py-2 text-gray-800">
+                        {value == null || value === "" ? "—" : String(value)}
+                      </td>
+                    );
+                  })}
+                  <td className="px-4 py-2">
+                    <div className="flex items-center gap-2">
+                      <select
+                        value={row.status}
+                        onChange={(e) => handleStatusChange(row.id, e.target.value)}
+                        className="rounded border border-gray-200 bg-white px-2 py-1 text-xs focus:border-red5 focus:outline-none"
+                      >
+                        {STATUS_OPTIONS.map((status) => (
+                          <option key={status} value={status}>
+                            {status}
+                          </option>
+                        ))}
+                      </select>
+                      <button
+                        onClick={() => loadDetail(row.id)}
+                        className="rounded border border-red5 px-2 py-1 text-xs font-semibold text-red5 transition-colors hover:bg-red5 hover:text-white"
+                      >
+                        Review
+                      </button>
+                    </div>
+                  </td>
+                </tr>
               ))}
-              <th className="text-left px-4 py-3 font-semibold">Decision</th>
-            </tr>
-          </thead>
-          <tbody>
-            {loading && (
-              <tr>
-                <td colSpan={COLUMNS.length + 1} className="px-4 py-8 text-center text-gray-500">
-                  Loading…
-                </td>
-              </tr>
-            )}
-            {!loading && filtered.length === 0 && (
-              <tr>
-                <td colSpan={COLUMNS.length + 1} className="px-4 py-8 text-center text-gray-500">
-                  No registrations.
-                </td>
-              </tr>
-            )}
-            {!loading && filtered.map((row) => (
-              <tr key={row.id} className="border-t border-red6/10 hover:bg-red7/40">
-                {COLUMNS.map((c) => {
-                  const v = row[c.key];
-                  const display = Array.isArray(v) ? v.join(", ") : v == null ? "" : String(v);
-                  return (
-                    <td key={String(c.key)} className="px-4 py-2 text-gray-800">
-                      {display}
-                    </td>
-                  );
-                })}
-                <td className="px-4 py-2">
-                  <select
-                    value={row.status}
-                    onChange={(e) => handleStatusChange(row.id, e.target.value)}
-                    className="bg-white border border-gray-200 rounded px-2 py-1 text-xs cursor-pointer focus:outline-none focus:border-red5"
+            </tbody>
+          </table>
+        </div>
+
+        <div className="min-h-[60vh] rounded-lg border border-red6/20 bg-white p-5">
+          {!selectedId && (
+            <div className="flex h-full items-center justify-center text-center">
+              <p className="max-w-xs text-sm font-poppins text-gray-500">
+                Select a registration to inspect the full application, uploaded resume, and stored answers.
+              </p>
+            </div>
+          )}
+          {selectedId && detailLoading && (
+            <div className="flex h-full items-center justify-center">
+              <p className="text-sm font-poppins text-gray-500">Loading application…</p>
+            </div>
+          )}
+          {detail && !detailLoading && (
+            <div className="flex h-full flex-col gap-4">
+              <div className="border-b border-red6/10 pb-4">
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <h2 className="text-xl font-poppins font-semibold text-red6">
+                      {detail.first_name || "Unknown"} {detail.last_name || ""}
+                    </h2>
+                    <p className="text-sm font-poppins text-gray-500">{detail.email}</p>
+                    <p className="mt-1 text-xs font-poppins text-gray-400">
+                      Submitted {new Date(detail.created_at).toLocaleString()}
+                    </p>
+                  </div>
+                  <span className="rounded-full bg-red7 px-3 py-1 text-xs font-poppins font-semibold text-red6">
+                    {detail.status}
+                  </span>
+                </div>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  <button
+                    onClick={handleResumeDownload}
+                    disabled={!detail.resume_path}
+                    className="rounded-lg border border-red5 px-3 py-2 text-xs font-poppins font-semibold text-red5 transition-colors hover:bg-red5 hover:text-white disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-300"
                   >
-                    {STATUS_OPTIONS.map((s) => (
-                      <option key={s} value={s}>{s}</option>
-                    ))}
-                  </select>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+                    View Resume
+                  </button>
+                </div>
+              </div>
+
+              <div className="overflow-y-auto">
+                <div className="flex flex-col gap-3">
+                  {detailEntries.length === 0 && (
+                    <p className="text-sm font-poppins text-gray-500">No stored answers.</p>
+                  )}
+                  {detailEntries.map(([key, value]) => (
+                    <div key={key} className="rounded-lg border border-red6/10 bg-red7/30 px-4 py-3">
+                      <p className="text-[11px] font-poppins font-semibold uppercase tracking-widest text-gray-500">
+                        {key}
+                      </p>
+                      <p className="mt-1 text-sm font-poppins text-gray-800">
+                        {formatAnswer(value)}
+                      </p>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
       </div>
 
-      <p className="text-xs font-poppins text-gray-500">
-        Showing {filtered.length} of {rows.length} registrations.
-      </p>
+      <div className="flex items-center justify-between text-xs font-poppins text-gray-500">
+        <p>
+          Showing {filteredRows.length} of {count} registrations.
+        </p>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => setPage((current) => Math.max(0, current - 1))}
+            disabled={page === 0}
+            className="rounded border border-gray-200 px-3 py-1 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            Previous
+          </button>
+          <span>
+            Page {page + 1} of {totalPages}
+          </span>
+          <button
+            onClick={() => setPage((current) => Math.min(totalPages - 1, current + 1))}
+            disabled={page >= totalPages - 1}
+            className="rounded border border-gray-200 px-3 py-1 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            Next
+          </button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/admin/adminTeamMatchingState.test.ts
+++ b/frontend/src/pages/admin/adminTeamMatchingState.test.ts
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildGenerateDraftErrorState,
+  buildGenerateDraftSuccessState,
+} from "./adminTeamMatchingState.ts";
+
+test("buildGenerateDraftErrorState clears stale draft data and keeps the backend message", () => {
+  const state = buildGenerateDraftErrorState("Not enough participants to form teams of the requested size");
+
+  assert.deepEqual(state.draftTeams, []);
+  assert.equal(state.participantsCount, null);
+  assert.equal(state.generateError, "Not enough participants to form teams of the requested size");
+});
+
+test("buildGenerateDraftSuccessState keeps the generated teams and clears previous errors", () => {
+  const teams = [
+    {
+      team_number: 1,
+      members: [
+        {
+          id: "participant-1",
+          email: "coder@example.com",
+          full_name: "Coder Example",
+          hacker_type: "FirstTimeHacker",
+        },
+      ],
+    },
+  ];
+
+  const state = buildGenerateDraftSuccessState({
+    total_participants: 1,
+    teams,
+  });
+
+  assert.deepEqual(state.draftTeams, teams);
+  assert.equal(state.participantsCount, 1);
+  assert.equal(state.generateError, null);
+});

--- a/frontend/src/pages/admin/adminTeamMatchingState.ts
+++ b/frontend/src/pages/admin/adminTeamMatchingState.ts
@@ -1,0 +1,37 @@
+export interface ParticipantSummary {
+  id: string;
+  user_id?: string;
+  email: string;
+  full_name: string;
+  hacker_type: string;
+}
+
+export interface MatcherTeam {
+  team_number: number;
+  members: ParticipantSummary[];
+}
+
+export interface GenerateDraftState {
+  participantsCount: number | null;
+  draftTeams: MatcherTeam[];
+  generateError: string | null;
+}
+
+export function buildGenerateDraftErrorState(message: string): GenerateDraftState {
+  return {
+    participantsCount: null,
+    draftTeams: [],
+    generateError: message,
+  };
+}
+
+export function buildGenerateDraftSuccessState(body: {
+  total_participants?: number | null;
+  teams?: MatcherTeam[] | null;
+}): GenerateDraftState {
+  return {
+    participantsCount: body.total_participants ?? 0,
+    draftTeams: body.teams ?? [],
+    generateError: null,
+  };
+}

--- a/supabase/migrations/20260624_dynamic_registration_answers.sql
+++ b/supabase/migrations/20260624_dynamic_registration_answers.sql
@@ -1,0 +1,30 @@
+begin;
+
+alter table public.registrations
+  add column if not exists form_key text not null default 'registration',
+  add column if not exists form_version integer not null default 1,
+  add column if not exists answers jsonb not null default '{}'::jsonb;
+
+alter table public.registrations
+  alter column status set default 'pending';
+
+update public.registrations as registrations
+set answers = coalesce(registrations.answers, '{}'::jsonb) || jsonb_strip_nulls(
+  to_jsonb(registrations) - array[
+    'id',
+    'created_at',
+    'status',
+    'checked_in',
+    'checked_in_at',
+    'user_id',
+    'form_key',
+    'form_version',
+    'answers'
+  ]
+)
+where coalesce(registrations.answers, '{}'::jsonb) = '{}'::jsonb;
+
+create unique index if not exists registrations_user_id_form_key_idx
+  on public.registrations (user_id, form_key);
+
+commit;


### PR DESCRIPTION
Add dynamic registration persistence and admin/team-matching parity so the apply flow, review flow, and published team flow work against the live Supabase-backed event site. This also lands the migration required for JSON answers and tightens the admin matcher failure experience.

- Add dynamic registration answers, form versioning, and scoped resume handling
- Expand admin registration review with search, detail inspection, CSV export, and resume access
- Add generic dynamic form routing and runtime validation for admin-managed form configs
- Add draft, save, and publish flows for team matching that materialize into the real user team system
- Surface matcher generation failures inline and clear stale draft state when generation fails
- Apply the Supabase migration and add regression tests for registration projection and matcher error state