### PR TITLE
feat: close registration workflow gaps

### DIFF
--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -73,10 +73,25 @@ router.get('/registrations', async (req: Request, res: Response) => {
  */
 router.get('/registrations/export.csv', async (_req: Request, res: Response) => {
   try {
-    const { data, error } = await supabase
+    const status = _req.query.status as string | undefined;
+    const search = (_req.query.q as string | undefined)?.trim();
+    const formKey = (_req.query.form_key as string | undefined)?.trim();
+
+    let query = supabase
       .from('registrations')
       .select('*')
       .order('created_at', { ascending: false });
+
+    if (status) query = query.eq('status', status);
+    if (formKey) query = query.eq('form_key', formKey);
+    if (search) {
+      const escaped = search.replace(/,/g, ' ');
+      query = query.or(
+        `first_name.ilike.%${escaped}%,last_name.ilike.%${escaped}%,email.ilike.%${escaped}%,school.ilike.%${escaped}%,major.ilike.%${escaped}%`,
+      );
+    }
+
+    const { data, error } = await query;
 
     if (error) {
       res.status(500).json({ error: error.message });

--- a/backend/src/routes/formConfigs.ts
+++ b/backend/src/routes/formConfigs.ts
@@ -4,6 +4,29 @@ import { supabase } from '../config/supabase';
 const router = Router();
 
 /**
+ * GET /api/form-configs
+ * Authenticated users can fetch active form summaries for discovery.
+ */
+router.get('/', async (_req: Request, res: Response) => {
+  try {
+    const { data, error } = await supabase
+      .from('form_configs')
+      .select('key, title, description, version')
+      .eq('is_active', true)
+      .order('updated_at', { ascending: false });
+
+    if (error) {
+      res.status(500).json({ error: error.message });
+      return;
+    }
+
+    res.json(data ?? []);
+  } catch (err) {
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+/**
  * GET /api/form-configs/:key
  * Authenticated users can fetch active form configs.
  */

--- a/backend/src/routes/registrations.ts
+++ b/backend/src/routes/registrations.ts
@@ -240,6 +240,29 @@ router.get('/me/resume-download-url', async (req: Request, res: Response) => {
 });
 
 /**
+ * GET /api/registrations/me/all
+ * Returns the authenticated user's registrations across all form keys.
+ */
+router.get('/me/all', async (req: Request, res: Response) => {
+  try {
+    const { data, error } = await supabase
+      .from('registrations')
+      .select('id, form_key, form_version, status, created_at, updated_at, resume_path')
+      .eq('user_id', req.user!.id)
+      .order('created_at', { ascending: false });
+
+    if (error) {
+      res.status(500).json({ error: error.message });
+      return;
+    }
+
+    res.json(data ?? []);
+  } catch (err) {
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+/**
  * GET /api/registrations/me
  * Returns the authenticated user's registration, or 404.
  * Defined before /:id so the literal route wins.

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -1,0 +1,58 @@
+import type { ReactNode } from "react";
+
+interface ModalProps {
+  open: boolean;
+  title: string;
+  description?: string;
+  children?: ReactNode;
+  footer?: ReactNode;
+  onClose: () => void;
+  maxWidthClassName?: string;
+}
+
+export default function Modal({
+  open,
+  title,
+  description,
+  children,
+  footer,
+  onClose,
+  maxWidthClassName = "max-w-lg",
+}: ModalProps) {
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-6"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label={title}
+    >
+      <div
+        className={`w-full ${maxWidthClassName} rounded-xl bg-white p-6 shadow-xl`}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="mb-4 flex items-start justify-between gap-3">
+          <div>
+            <h2 className="text-xl font-poppins font-bold text-red6">{title}</h2>
+            {description && (
+              <p className="mt-1 text-sm font-poppins text-gray-600">{description}</p>
+            )}
+          </div>
+          <button
+            onClick={onClose}
+            className="rounded-full p-1 text-lg leading-none text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-700"
+            aria-label="Close dialog"
+          >
+            ×
+          </button>
+        </div>
+
+        {children}
+
+        {footer && <div className="mt-6 flex justify-end gap-3">{footer}</div>}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/registration/ApplicationPanel.tsx
+++ b/frontend/src/components/registration/ApplicationPanel.tsx
@@ -1,21 +1,23 @@
 import { useEffect, useState } from "react";
 import DynamicForm from "./DynamicForm";
-import { hackathonRegistrationFormConfig, type FormConfig, type FormField } from "@/lib/formConfig";
+import type { FormConfig, FormField } from "@/lib/formConfig";
 import { buildSchemaFromFields } from "@/lib/buildSchema";
 import { useToast } from "@/components/Toast/ToastContext";
 import { apiFetch } from "@/lib/api";
+import { extractSubmissionFeedback } from "@/lib/registrationUi";
 
 interface ApplicationPanelProps {
   isOpen: boolean;
   onClose: () => void;
-  onSubmitted: () => void;
+  onSubmitted: (registration: RegistrationResponse) => void;
 }
 
-interface RegistrationResponse {
+export interface RegistrationResponse {
   id: number | string;
   answers?: Record<string, unknown>;
   status?: string | null;
   resume_path?: string | null;
+  form_key?: string | null;
 }
 
 const FORM_KEY = "registration";
@@ -61,6 +63,11 @@ function registrationToFormValues(registration: RegistrationResponse): Record<st
     : {};
 }
 
+function formatStatusLabel(status?: string | null): string {
+  if (!status) return "Draft";
+  return `${status.charAt(0).toUpperCase()}${status.slice(1)}`;
+}
+
 async function uploadResume(file: File): Promise<string> {
   const urlRes = await apiFetch(`/api/registrations/me/resume-upload-url?form_key=${FORM_KEY}`, {
     method: "POST",
@@ -98,8 +105,11 @@ export default function ApplicationPanel({ isOpen, onClose, onSubmitted }: Appli
   const [existingResumePath, setExistingResumePath] = useState<string | null>(null);
   const [hasExistingSubmission, setHasExistingSubmission] = useState(false);
   const [submissionMode, setSubmissionMode] = useState<"created" | "updated">("created");
-  const [config, setConfig] = useState<FormConfig>(hackathonRegistrationFormConfig);
+  const [config, setConfig] = useState<FormConfig | null>(null);
+  const [configUnavailable, setConfigUnavailable] = useState(false);
   const [profileValues, setProfileValues] = useState<Record<string, unknown> | null>(null);
+  const [submissionErrors, setSubmissionErrors] = useState<Record<string, string>>({});
+  const [currentStatus, setCurrentStatus] = useState<string | null>(null);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -110,6 +120,7 @@ export default function ApplicationPanel({ isOpen, onClose, onSubmitted }: Appli
       setIsBootstrapping(true);
       setIsSubmitted(false);
       setResumeFile(null);
+      setSubmissionErrors({});
 
       try {
         const [configRes, profileRes, registrationRes] = await Promise.all([
@@ -127,6 +138,10 @@ export default function ApplicationPanel({ isOpen, onClose, onSubmitted }: Appli
             schema: buildSchemaFromFields(fields),
             fields,
           });
+          setConfigUnavailable(false);
+        } else if (!cancelled) {
+          setConfig(null);
+          setConfigUnavailable(true);
         }
 
         if (!cancelled && profileRes.ok) {
@@ -140,6 +155,7 @@ export default function ApplicationPanel({ isOpen, onClose, onSubmitted }: Appli
           setSubmissionMode("updated");
           setInitialValues(registrationToFormValues(registration));
           setExistingResumePath(registration.resume_path ?? null);
+          setCurrentStatus(registration.status ?? null);
           setPrefillBannerDismissed(true);
           return;
         }
@@ -149,6 +165,7 @@ export default function ApplicationPanel({ isOpen, onClose, onSubmitted }: Appli
           setSubmissionMode("created");
           setInitialValues({});
           setExistingResumePath(null);
+          setCurrentStatus(null);
           setPrefillBannerDismissed(false);
         }
       } catch {
@@ -156,6 +173,7 @@ export default function ApplicationPanel({ isOpen, onClose, onSubmitted }: Appli
           setHasExistingSubmission(false);
           setSubmissionMode("created");
           setExistingResumePath(null);
+          setCurrentStatus(null);
         }
       } finally {
         if (!cancelled) {
@@ -192,6 +210,7 @@ export default function ApplicationPanel({ isOpen, onClose, onSubmitted }: Appli
 
   const handleSubmit = async (data: Record<string, unknown>) => {
     setIsLoading(true);
+    setSubmissionErrors({});
     try {
       const method = hasExistingSubmission ? "PUT" : "POST";
       const endpoint = hasExistingSubmission
@@ -208,8 +227,12 @@ export default function ApplicationPanel({ isOpen, onClose, onSubmitted }: Appli
           setHasExistingSubmission(true);
           return;
         }
-        const err = await res.json();
-        throw new Error(err.errors?.[0]?.message || err.error || err.message || "Failed to submit");
+        const feedback = extractSubmissionFeedback(
+          await res.json().catch(() => null),
+          "Failed to submit application. Please try again.",
+        );
+        setSubmissionErrors(feedback.fieldErrors);
+        throw new Error(feedback.message);
       }
 
       const savedRegistration = (await res.json()) as RegistrationResponse;
@@ -227,11 +250,15 @@ export default function ApplicationPanel({ isOpen, onClose, onSubmitted }: Appli
       setHasExistingSubmission(true);
       setExistingResumePath(nextResumePath);
       setInitialValues(registrationToFormValues(savedRegistration));
+      setCurrentStatus(savedRegistration.status ?? null);
       setIsSubmitted(true);
-      onSubmitted();
+      onSubmitted({
+        ...savedRegistration,
+        resume_path: nextResumePath,
+      });
     } catch (error) {
       console.error(error);
-      showToast("Failed to submit application. Please try again.", "error");
+      showToast(error instanceof Error ? error.message : "Failed to submit application. Please try again.", "error");
     } finally {
       setIsLoading(false);
     }
@@ -276,7 +303,14 @@ export default function ApplicationPanel({ isOpen, onClose, onSubmitted }: Appli
             <h2 className="text-4xl font-jersey10 text-gray-900">
               BigRed<span className="text-red5">//</span>Hacks
             </h2>
-            <p className="font-poppins text-sm text-gray-500 mt-0.5">Fall 2026 Application</p>
+            <div className="mt-0.5 flex items-center gap-2">
+              <p className="font-poppins text-sm text-gray-500">Fall 2026 Application</p>
+              {hasExistingSubmission && (
+                <span className="rounded-full bg-red7 px-2.5 py-1 text-[11px] font-poppins font-semibold uppercase tracking-widest text-red6">
+                  {formatStatusLabel(currentStatus)}
+                </span>
+              )}
+            </div>
           </div>
           <button
             onClick={onClose}
@@ -314,6 +348,19 @@ export default function ApplicationPanel({ isOpen, onClose, onSubmitted }: Appli
           {isBootstrapping ? (
             <div className="flex h-full items-center justify-center">
               <p className="font-poppins text-sm text-gray-500">Loading application…</p>
+            </div>
+          ) : configUnavailable || !config ? (
+            <div className="flex h-full flex-col items-center justify-center gap-3 text-center">
+              <p className="text-4xl font-jersey10 text-red5">Unavailable</p>
+              <p className="max-w-sm font-poppins text-sm text-gray-500">
+                The main application form is not active right now. Check back later or contact the organizers if you expected to apply.
+              </p>
+              <button
+                onClick={onClose}
+                className="rounded-lg bg-red5 px-6 py-2.5 text-sm font-poppins font-semibold text-white transition-colors hover:bg-red3"
+              >
+                Back to Dashboard
+              </button>
             </div>
           ) : isSubmitted ? (
             <div className="flex flex-col items-center justify-center h-full gap-4 text-center">
@@ -375,6 +422,8 @@ export default function ApplicationPanel({ isOpen, onClose, onSubmitted }: Appli
                 isLoading={isLoading}
                 initialValues={initialValues}
                 hideHeader
+                submissionErrors={submissionErrors}
+                submitLabel={hasExistingSubmission ? "Update Application" : "Submit Application"}
               />
             </>
           )}

--- a/frontend/src/components/registration/DynamicForm.tsx
+++ b/frontend/src/components/registration/DynamicForm.tsx
@@ -15,9 +15,19 @@ interface DynamicFormProps {
   isLoading?: boolean;
   initialValues?: Record<string, unknown>;
   hideHeader?: boolean;
+  submissionErrors?: Record<string, string>;
+  submitLabel?: string;
 }
 
-export default function DynamicForm({ config, onSubmit, isLoading = false, initialValues = {}, hideHeader = false }: DynamicFormProps) {
+export default function DynamicForm({
+  config,
+  onSubmit,
+  isLoading = false,
+  initialValues = {},
+  hideHeader = false,
+  submissionErrors = {},
+  submitLabel = "Submit Application",
+}: DynamicFormProps) {
   const [formData, setFormData] = useState<Record<string, unknown>>(initialValues);
   const [errors, setErrors] = useState<Record<string, string>>({});
 
@@ -25,6 +35,11 @@ export default function DynamicForm({ config, onSubmit, isLoading = false, initi
     setFormData(initialValues);
     setErrors({});
   }, [initialValues]);
+
+  useEffect(() => {
+    if (Object.keys(submissionErrors).length === 0) return;
+    setErrors((prev) => ({ ...prev, ...submissionErrors }));
+  }, [submissionErrors]);
 
   const handleFieldChange = (fieldId: string, value: unknown) => {
     setFormData((prev) => ({
@@ -201,7 +216,7 @@ export default function DynamicForm({ config, onSubmit, isLoading = false, initi
             disabled={isLoading}
             className="w-full rounded-lg bg-red5 px-4 py-3 text-sm font-poppins font-semibold text-white shadow-sm hover:bg-red3 focus:outline-none focus:ring-2 focus:ring-red5 focus:ring-offset-2 disabled:cursor-not-allowed disabled:bg-gray-400 transition-colors"
           >
-            {isLoading ? "Submitting…" : "Submit Application"}
+            {isLoading ? "Submitting…" : submitLabel}
           </button>
         </div>
       </form>

--- a/frontend/src/components/team-matching/NoTeamView.tsx
+++ b/frontend/src/components/team-matching/NoTeamView.tsx
@@ -2,12 +2,20 @@ import arcade from "@/assets/team/arcade.png";
 // arcade is a raster PNG — kept as .png
 
 interface NoTeamViewProps {
+  joinCode: string;
+  onJoinCodeChange: (value: string) => void;
   onJoinTeam: (code: string) => void;
   onCreateTeam: () => void;
   onFillMatchForm: () => void;
 }
 
-export default function NoTeamView({ onJoinTeam, onCreateTeam, onFillMatchForm }: NoTeamViewProps) {
+export default function NoTeamView({
+  joinCode,
+  onJoinCodeChange,
+  onJoinTeam,
+  onCreateTeam,
+  onFillMatchForm,
+}: NoTeamViewProps) {
   return (
     <>
       {/* Header */}
@@ -26,6 +34,8 @@ export default function NoTeamView({ onJoinTeam, onCreateTeam, onFillMatchForm }
               <input
                 type="text"
                 placeholder="_ _ _ _ _ _"
+                value={joinCode}
+                onChange={(event) => onJoinCodeChange(event.target.value.toUpperCase())}
                 className="bg-white border border-[#c0ab95] rounded-lg h-[42px] px-3 py-2 w-[295px] text-sm text-black placeholder:text-[#d6d3cf] focus:outline-none"
                 onKeyDown={(e) => {
                   if (e.key === "Enter") {
@@ -35,10 +45,7 @@ export default function NoTeamView({ onJoinTeam, onCreateTeam, onFillMatchForm }
               />
             </div>
             <button
-              onClick={() => {
-                const input = document.querySelector<HTMLInputElement>('input[placeholder="_ _ _ _ _ _"]');
-                if (input) onJoinTeam(input.value);
-              }}
+              onClick={() => onJoinTeam(joinCode)}
               className="bg-[#e46966] text-[#faf4ed] font-medium text-base px-5 py-2.5 rounded-lg"
             >
               Find Team

--- a/frontend/src/lib/registrationUi.test.ts
+++ b/frontend/src/lib/registrationUi.test.ts
@@ -1,0 +1,86 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildApplicationCards,
+  extractSubmissionFeedback,
+} from "./registrationUi.ts";
+
+test("buildApplicationCards merges active forms with user registrations and sorts registration first", () => {
+  const cards = buildApplicationCards(
+    [
+      { key: "team-matching", title: "Team Matching", description: "Find teammates", version: 2 },
+      { key: "registration", title: "Main Registration", description: "Apply", version: 4 },
+    ],
+    [
+      { form_key: "registration", status: "waitlisted" },
+      { form_key: "team-matching", status: "pending" },
+    ],
+  );
+
+  assert.deepEqual(
+    cards.map((card) => ({
+      key: card.key,
+      stateLabel: card.stateLabel,
+      started: card.started,
+      primaryActionLabel: card.primaryActionLabel,
+    })),
+    [
+      {
+        key: "registration",
+        stateLabel: "Waitlisted",
+        started: true,
+        primaryActionLabel: "View Application",
+      },
+      {
+        key: "team-matching",
+        stateLabel: "Pending",
+        started: true,
+        primaryActionLabel: "Open Form",
+      },
+    ],
+  );
+});
+
+test("buildApplicationCards marks active forms with no submission as not started", () => {
+  const cards = buildApplicationCards(
+    [{ key: "travel-waiver", title: "Travel Waiver", description: "", version: 1 }],
+    [],
+  );
+
+  assert.deepEqual(cards, [
+    {
+      key: "travel-waiver",
+      title: "Travel Waiver",
+      description: "",
+      version: 1,
+      status: null,
+      stateLabel: "Not Started",
+      started: false,
+      primaryActionLabel: "Start Form",
+    },
+  ]);
+});
+
+test("extractSubmissionFeedback prefers field-specific backend validation errors", () => {
+  const feedback = extractSubmissionFeedback({
+    error: "Invalid form submission",
+    errors: [
+      { field: "school", message: "School is required" },
+      { field: "country", message: "Country is required" },
+    ],
+  });
+
+  assert.equal(feedback.message, "School is required");
+  assert.deepEqual(feedback.fieldErrors, {
+    school: "School is required",
+    country: "Country is required",
+  });
+});
+
+test("extractSubmissionFeedback falls back to a generic message for unknown payloads", () => {
+  const feedback = extractSubmissionFeedback(null, "Could not save this form.");
+
+  assert.equal(feedback.message, "Could not save this form.");
+  assert.deepEqual(feedback.fieldErrors, {});
+});

--- a/frontend/src/lib/registrationUi.ts
+++ b/frontend/src/lib/registrationUi.ts
@@ -1,0 +1,115 @@
+export interface ActiveFormSummary {
+  key: string;
+  title: string;
+  description: string | null;
+  version: number;
+}
+
+export interface RegistrationSummaryLike {
+  form_key?: string | null;
+  status?: string | null;
+}
+
+export interface ApplicationCard {
+  key: string;
+  title: string;
+  description: string | null;
+  version: number;
+  status: string | null;
+  stateLabel: string;
+  started: boolean;
+  primaryActionLabel: string;
+}
+
+export interface SubmissionFeedback {
+  message: string;
+  fieldErrors: Record<string, string>;
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  pending: "Pending",
+  submitted: "Submitted",
+  approved: "Approved",
+  rejected: "Rejected",
+  waitlisted: "Waitlisted",
+};
+
+function titleCaseStatus(status: string): string {
+  return STATUS_LABELS[status] ?? `${status.charAt(0).toUpperCase()}${status.slice(1)}`;
+}
+
+export function buildApplicationCards(
+  forms: ActiveFormSummary[],
+  registrations: RegistrationSummaryLike[],
+): ApplicationCard[] {
+  const registrationsByKey = new Map(
+    registrations
+      .filter((registration) => typeof registration.form_key === "string" && registration.form_key.length > 0)
+      .map((registration) => [registration.form_key as string, registration]),
+  );
+
+  return [...forms]
+    .sort((left, right) => {
+      if (left.key === "registration") return -1;
+      if (right.key === "registration") return 1;
+      return left.title.localeCompare(right.title);
+    })
+    .map((form) => {
+      const registration = registrationsByKey.get(form.key);
+      const status =
+        typeof registration?.status === "string" && registration.status.length > 0
+          ? registration.status
+          : null;
+      const started = registration !== undefined;
+
+      return {
+        key: form.key,
+        title: form.title,
+        description: form.description,
+        version: form.version,
+        status,
+        stateLabel: status ? titleCaseStatus(status) : "Not Started",
+        started,
+        primaryActionLabel: form.key === "registration"
+          ? started
+            ? "View Application"
+            : "Start Application"
+          : started
+            ? "Open Form"
+            : "Start Form",
+      };
+    });
+}
+
+export function extractSubmissionFeedback(
+  payload: unknown,
+  fallbackMessage = "Failed to submit application. Please try again.",
+): SubmissionFeedback {
+  if (!payload || typeof payload !== "object") {
+    return { message: fallbackMessage, fieldErrors: {} };
+  }
+
+  const body = payload as {
+    error?: unknown;
+    message?: unknown;
+    errors?: Array<{ field?: unknown; message?: unknown }>;
+  };
+
+  const fieldErrors: Record<string, string> = {};
+  for (const issue of body.errors ?? []) {
+    if (typeof issue?.field !== "string" || typeof issue?.message !== "string") {
+      continue;
+    }
+    if (!fieldErrors[issue.field]) {
+      fieldErrors[issue.field] = issue.message;
+    }
+  }
+
+  const message =
+    Object.values(fieldErrors)[0] ||
+    (typeof body.error === "string" && body.error) ||
+    (typeof body.message === "string" && body.message) ||
+    fallbackMessage;
+
+  return { message, fieldErrors };
+}

--- a/frontend/src/pages/DynamicFormPage.tsx
+++ b/frontend/src/pages/DynamicFormPage.tsx
@@ -6,6 +6,7 @@ import { useToast } from "@/components/Toast/ToastContext";
 import { apiFetch } from "@/lib/api";
 import { buildSchemaFromFields } from "@/lib/buildSchema";
 import type { FormConfig, FormField } from "@/lib/formConfig";
+import { extractSubmissionFeedback } from "@/lib/registrationUi";
 
 interface RegistrationResponse {
   answers?: Record<string, unknown>;
@@ -19,6 +20,7 @@ export default function DynamicFormPage() {
   const [config, setConfig] = useState<FormConfig | null>(null);
   const [initialValues, setInitialValues] = useState<Record<string, unknown>>({});
   const [hasExistingSubmission, setHasExistingSubmission] = useState(false);
+  const [submissionErrors, setSubmissionErrors] = useState<Record<string, string>>({});
 
   useEffect(() => {
     let cancelled = false;
@@ -56,10 +58,12 @@ export default function DynamicFormPage() {
         if (!cancelled) {
           setInitialValues(registration.answers ?? {});
           setHasExistingSubmission(true);
+          setSubmissionErrors({});
         }
       } else if (!cancelled) {
         setInitialValues({});
         setHasExistingSubmission(false);
+        setSubmissionErrors({});
       }
 
       if (!cancelled) {
@@ -81,6 +85,7 @@ export default function DynamicFormPage() {
 
   const handleSubmit = async (data: Record<string, unknown>) => {
     setSubmitting(true);
+    setSubmissionErrors({});
     const res = await apiFetch(
       hasExistingSubmission
         ? `/api/registrations/me?form_key=${encodeURIComponent(key)}`
@@ -95,7 +100,9 @@ export default function DynamicFormPage() {
 
     if (!res.ok) {
       const body = await res.json().catch(() => ({}));
-      showToast(body.error || body.errors?.[0]?.message || "Could not save this form.", "error");
+      const feedback = extractSubmissionFeedback(body, "Could not save this form.");
+      setSubmissionErrors(feedback.fieldErrors);
+      showToast(feedback.message, "error");
       return;
     }
 
@@ -118,6 +125,8 @@ export default function DynamicFormPage() {
             onSubmit={handleSubmit}
             isLoading={submitting}
             initialValues={initialValues}
+            submissionErrors={submissionErrors}
+            submitLabel={hasExistingSubmission ? "Update Form" : "Save Form"}
           />
         )}
       </div>

--- a/frontend/src/pages/TeamPage.tsx
+++ b/frontend/src/pages/TeamPage.tsx
@@ -9,6 +9,7 @@ import RegistrationLayout from "@/components/layouts/RegistrationLayout";
 import { useToast } from "@/components/Toast/ToastContext";
 import { apiFetch } from "@/lib/api";
 import { supabase } from "@/config/supabase";
+import Modal from "@/components/Modal";
 
 type TeamState =
   | "loading"
@@ -73,6 +74,12 @@ export default function TeamPage() {
   const [currentUserId, setCurrentUserId] = useState<string | null>(null);
   const [matchingInitialValues, setMatchingInitialValues] = useState<Record<string, unknown>>({});
   const [hasMatchingSubmission, setHasMatchingSubmission] = useState(false);
+  const [joinCode, setJoinCode] = useState("");
+  const [newTeamName, setNewTeamName] = useState("");
+  const [showCreateTeamModal, setShowCreateTeamModal] = useState(false);
+  const [creatingTeam, setCreatingTeam] = useState(false);
+  const [showLeaveConfirm, setShowLeaveConfirm] = useState(false);
+  const [leavingTeam, setLeavingTeam] = useState(false);
   const { showToast } = useToast();
 
   const refreshTeam = async () => {
@@ -128,34 +135,44 @@ export default function TeamPage() {
       return;
     }
     showToast("Joined team!", "success");
+    setJoinCode("");
     await refreshTeam();
   };
 
   const handleCreateTeam = async () => {
-    const name = window.prompt("Team name?")?.trim();
-    if (!name) return;
+    const name = newTeamName.trim();
+    if (!name) {
+      showToast("Enter a team name.", "error");
+      return;
+    }
+    setCreatingTeam(true);
     const res = await apiFetch("/api/teams/create", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name }),
     });
+    setCreatingTeam(false);
     if (!res.ok) {
       const body = await res.json().catch(() => ({}));
       showToast(body.error || "Could not create team.", "error");
       return;
     }
     showToast("Team created!", "success");
+    setShowCreateTeamModal(false);
+    setNewTeamName("");
     await refreshTeam();
   };
 
   const handleLeaveTeam = async () => {
-    if (!window.confirm("Leave this team?")) return;
+    setLeavingTeam(true);
     const res = await apiFetch("/api/teams/leave", { method: "POST" });
+    setLeavingTeam(false);
     if (!res.ok) {
       showToast("Could not leave team.", "error");
       return;
     }
     showToast("Left team.", "info");
+    setShowLeaveConfirm(false);
     await refreshTeam();
   };
 
@@ -224,8 +241,10 @@ export default function TeamPage() {
       case "no-team":
         return (
           <NoTeamView
+            joinCode={joinCode}
+            onJoinCodeChange={setJoinCode}
             onJoinTeam={handleJoinTeam}
-            onCreateTeam={handleCreateTeam}
+            onCreateTeam={() => setShowCreateTeamModal(true)}
             onFillMatchForm={handleFillMatchForm}
           />
         );
@@ -253,17 +272,93 @@ export default function TeamPage() {
             members={team.members
               .filter((m) => m.user_id !== currentUserId)
               .map((m) => ({ full_name: m.full_name, email: "" }))}
-            onLeaveTeam={handleLeaveTeam}
+            onLeaveTeam={() => setShowLeaveConfirm(true)}
           />
         );
     }
   };
 
   return (
-    <RegistrationLayout className="bg-[#fffdfa]">
-      <div className="flex flex-col gap-5 items-center p-10">
-        {renderView()}
-      </div>
-    </RegistrationLayout>
+    <>
+      <RegistrationLayout className="bg-[#fffdfa]">
+        <div className="flex flex-col gap-5 items-center p-10">
+          {renderView()}
+        </div>
+      </RegistrationLayout>
+
+      <Modal
+        open={showCreateTeamModal}
+        onClose={() => {
+          if (creatingTeam) return;
+          setShowCreateTeamModal(false);
+          setNewTeamName("");
+        }}
+        title="Create a team"
+        description="Choose the team name your teammates will see when they join."
+        footer={(
+          <>
+            <button
+              onClick={() => {
+                setShowCreateTeamModal(false);
+                setNewTeamName("");
+              }}
+              className="rounded-lg px-4 py-2 text-sm font-poppins text-gray-600 transition-colors hover:text-gray-800"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleCreateTeam}
+              disabled={creatingTeam}
+              className="rounded-lg bg-red5 px-4 py-2 text-sm font-poppins font-semibold text-white transition-colors hover:bg-red3 disabled:opacity-50"
+            >
+              {creatingTeam ? "Creating…" : "Create Team"}
+            </button>
+          </>
+        )}
+      >
+        <label className="block text-sm font-poppins font-semibold text-gray-700">
+          Team name
+        </label>
+        <input
+          value={newTeamName}
+          onChange={(event) => setNewTeamName(event.target.value)}
+          placeholder="Hack On Heroes"
+          className="mt-2 w-full rounded-lg border border-gray-200 px-3 py-2 text-sm font-poppins text-gray-900 placeholder:text-gray-400 focus:border-red5 focus:outline-none"
+          onKeyDown={(event) => {
+            if (event.key === "Enter") {
+              event.preventDefault();
+              void handleCreateTeam();
+            }
+          }}
+        />
+      </Modal>
+
+      <Modal
+        open={showLeaveConfirm}
+        onClose={() => {
+          if (leavingTeam) return;
+          setShowLeaveConfirm(false);
+        }}
+        title="Leave this team?"
+        description="You’ll be removed from the current team immediately. If the team becomes empty, it will be deleted."
+        footer={(
+          <>
+            <button
+              onClick={() => setShowLeaveConfirm(false)}
+              className="rounded-lg px-4 py-2 text-sm font-poppins text-gray-600 transition-colors hover:text-gray-800"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleLeaveTeam}
+              disabled={leavingTeam}
+              className="rounded-lg bg-red5 px-4 py-2 text-sm font-poppins font-semibold text-white transition-colors hover:bg-red3 disabled:opacity-50"
+            >
+              {leavingTeam ? "Leaving…" : "Leave Team"}
+            </button>
+          </>
+        )}
+      />
+    </>
   );
 }

--- a/frontend/src/pages/admin/AdminFormList.tsx
+++ b/frontend/src/pages/admin/AdminFormList.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { apiFetch } from "@/lib/api";
 import { useToast } from "@/components/Toast/ToastContext";
 import { FORM_PRESETS, type FormPreset } from "@/lib/formPresets";
+import Modal from "@/components/Modal";
 
 export interface FormSummary {
   key: string;
@@ -23,6 +24,9 @@ export default function AdminFormList({ onSelect }: Props) {
   const [loading, setLoading] = useState(true);
   const [creating, setCreating] = useState(false);
   const [showPresetPicker, setShowPresetPicker] = useState(false);
+  const [selectedPreset, setSelectedPreset] = useState<FormPreset | null>(null);
+  const [newFormKey, setNewFormKey] = useState("");
+  const [deleteTarget, setDeleteTarget] = useState<FormSummary | null>(null);
 
   const refresh = async () => {
     setLoading(true);
@@ -41,11 +45,9 @@ export default function AdminFormList({ onSelect }: Props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const handleCreate = async (preset: FormPreset) => {
-    const key = window.prompt(
-      "URL slug for this form (lowercase letters, numbers, hyphens):",
-      preset.defaultKey
-    )?.trim();
+  const handleCreate = async () => {
+    if (!selectedPreset) return;
+    const key = newFormKey.trim();
     if (!key) return;
     if (!/^[a-z0-9-]+$/.test(key)) {
       showToast("Invalid key. Use lowercase letters, numbers, hyphens.", "error");
@@ -57,32 +59,34 @@ export default function AdminFormList({ onSelect }: Props) {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         key,
-        title: preset.defaultTitle,
-        description: preset.defaultDescription,
-        fields: preset.fields,
+        title: selectedPreset.defaultTitle,
+        description: selectedPreset.defaultDescription,
+        fields: selectedPreset.fields,
         is_active: false,
       }),
     });
     setCreating(false);
-    setShowPresetPicker(false);
     if (!res.ok) {
       const body = await res.json().catch(() => ({}));
       showToast(`Create failed: ${body.error || `HTTP ${res.status}`}`, "error");
       return;
     }
-    showToast(`Form "${key}" created from ${preset.name}.`, "success");
+    showToast(`Form "${key}" created from ${selectedPreset.name}.`, "success");
+    setShowPresetPicker(false);
+    setSelectedPreset(null);
+    setNewFormKey("");
     await refresh();
     onSelect(key);
   };
 
   const handleDelete = async (key: string) => {
-    if (!window.confirm(`Delete form "${key}"? This cannot be undone.`)) return;
     const res = await apiFetch(`/api/admin/form-configs/${key}`, { method: "DELETE" });
     if (!res.ok) {
       showToast("Delete failed.", "error");
       return;
     }
     showToast("Deleted.", "info");
+    setDeleteTarget(null);
     await refresh();
   };
 
@@ -170,7 +174,7 @@ export default function AdminFormList({ onSelect }: Props) {
                     Edit
                   </button>
                   <button
-                    onClick={() => handleDelete(f.key)}
+                    onClick={() => setDeleteTarget(f)}
                     className="px-3 py-1 bg-white border border-red5 text-red5 hover:bg-red5 hover:text-white text-xs font-poppins font-semibold rounded transition-colors"
                   >
                     Delete
@@ -183,38 +187,125 @@ export default function AdminFormList({ onSelect }: Props) {
       </div>
 
       {/* Preset picker modal */}
-      {showPresetPicker && (
-        <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-6" onClick={() => setShowPresetPicker(false)}>
-          <div
-            className="bg-white rounded-xl p-6 w-full max-w-2xl shadow-xl"
-            onClick={(e) => e.stopPropagation()}
+      <Modal
+        open={showPresetPicker}
+        onClose={() => {
+          if (creating) return;
+          setShowPresetPicker(false);
+          setSelectedPreset(null);
+          setNewFormKey("");
+        }}
+        title="Create a form"
+        description="Start from a preset, then choose the URL slug users will visit."
+        maxWidthClassName="max-w-2xl"
+        footer={selectedPreset ? (
+          <>
+            <button
+              onClick={() => {
+                setSelectedPreset(null);
+                setNewFormKey("");
+              }}
+              className="rounded-lg px-4 py-2 text-sm font-poppins text-gray-600 transition-colors hover:text-gray-800"
+            >
+              Back
+            </button>
+            <button
+              onClick={() => {
+                setShowPresetPicker(false);
+                setSelectedPreset(null);
+                setNewFormKey("");
+              }}
+              className="rounded-lg px-4 py-2 text-sm font-poppins text-gray-600 transition-colors hover:text-gray-800"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={() => void handleCreate()}
+              disabled={creating}
+              className="rounded-lg bg-red5 px-4 py-2 text-sm font-poppins font-semibold text-white transition-colors hover:bg-red3 disabled:opacity-50"
+            >
+              {creating ? "Creating…" : "Create Form"}
+            </button>
+          </>
+        ) : (
+          <button
+            onClick={() => setShowPresetPicker(false)}
+            className="rounded-lg px-4 py-2 text-sm font-poppins text-gray-600 transition-colors hover:text-gray-800"
           >
-            <h2 className="text-xl font-poppins font-bold text-red6 mb-4">Choose a preset</h2>
-            <div className="flex flex-col gap-3">
-              {FORM_PRESETS.map((p) => (
-                <button
-                  key={p.id}
-                  onClick={() => handleCreate(p)}
-                  disabled={creating}
-                  className="text-left bg-red7 hover:bg-red6/30 border border-red6/30 rounded-lg p-4 transition-colors disabled:opacity-50"
-                >
-                  <p className="font-poppins font-semibold text-red6 mb-1">{p.name}</p>
-                  <p className="text-xs font-poppins text-gray-700">{p.description}</p>
-                  <p className="text-xs font-poppins text-gray-400 mt-1">{p.fields.length} fields</p>
-                </button>
-              ))}
-            </div>
-            <div className="flex justify-end mt-4">
+            Cancel
+          </button>
+        )}
+      >
+        {!selectedPreset && (
+          <div className="flex flex-col gap-3">
+            {FORM_PRESETS.map((preset) => (
               <button
-                onClick={() => setShowPresetPicker(false)}
-                className="px-4 py-2 text-sm font-poppins text-gray-600 hover:text-gray-800"
+                key={preset.id}
+                onClick={() => {
+                  setSelectedPreset(preset);
+                  setNewFormKey(preset.defaultKey);
+                }}
+                className="text-left rounded-lg border border-red6/30 bg-red7 p-4 transition-colors hover:bg-red6/30"
               >
-                Cancel
+                <p className="font-poppins font-semibold text-red6">{preset.name}</p>
+                <p className="mt-1 text-xs font-poppins text-gray-700">{preset.description}</p>
+                <p className="mt-1 text-xs font-poppins text-gray-400">{preset.fields.length} fields</p>
               </button>
+            ))}
+          </div>
+        )}
+
+        {selectedPreset && (
+          <div className="flex flex-col gap-4">
+            <div className="rounded-lg border border-red6/20 bg-red7/30 px-4 py-3">
+              <p className="font-poppins font-semibold text-red6">{selectedPreset.name}</p>
+              <p className="mt-1 text-sm font-poppins text-gray-700">{selectedPreset.description}</p>
+            </div>
+            <div>
+              <label className="block text-sm font-poppins font-semibold text-gray-700">
+                Form key
+              </label>
+              <input
+                value={newFormKey}
+                onChange={(event) => setNewFormKey(event.target.value)}
+                placeholder="registration"
+                className="mt-2 w-full rounded-lg border border-gray-200 px-3 py-2 text-sm font-poppins text-gray-900 placeholder:text-gray-400 focus:border-red5 focus:outline-none"
+              />
+              <p className="mt-2 text-xs font-poppins text-gray-500">
+                Use lowercase letters, numbers, and hyphens. Users will visit{" "}
+                <span className="font-mono text-gray-700">/forms/{newFormKey || "your-key"}</span>.
+              </p>
             </div>
           </div>
-        </div>
-      )}
+        )}
+      </Modal>
+
+      <Modal
+        open={deleteTarget !== null}
+        onClose={() => setDeleteTarget(null)}
+        title="Delete this form?"
+        description={
+          deleteTarget
+            ? `Delete "${deleteTarget.title}" (${deleteTarget.key})? This cannot be undone.`
+            : undefined
+        }
+        footer={(
+          <>
+            <button
+              onClick={() => setDeleteTarget(null)}
+              className="rounded-lg px-4 py-2 text-sm font-poppins text-gray-600 transition-colors hover:text-gray-800"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={() => deleteTarget && void handleDelete(deleteTarget.key)}
+              className="rounded-lg bg-red5 px-4 py-2 text-sm font-poppins font-semibold text-white transition-colors hover:bg-red3"
+            >
+              Delete Form
+            </button>
+          </>
+        )}
+      />
     </div>
   );
 }

--- a/frontend/src/pages/admin/AdminUsers.tsx
+++ b/frontend/src/pages/admin/AdminUsers.tsx
@@ -1,6 +1,10 @@
 import { useEffect, useMemo, useState } from "react";
 import { apiFetch } from "@/lib/api";
 import { useToast } from "@/components/Toast/ToastContext";
+import {
+  buildAdminRegistrationsCsvPath,
+  buildAdminRegistrationsPath,
+} from "./adminRegistrationsQuery";
 
 interface RegistrationSummary {
   id: number;
@@ -21,6 +25,11 @@ interface RegistrationSummary {
 interface RegistrationDetail extends RegistrationSummary {
   answers?: Record<string, unknown>;
   form_version?: number | null;
+}
+
+interface FormSummary {
+  key: string;
+  title: string;
 }
 
 const STATUS_OPTIONS = ["pending", "submitted", "approved", "rejected", "waitlisted"] as const;
@@ -55,6 +64,8 @@ export default function AdminUsers() {
   const [count, setCount] = useState(0);
   const [search, setSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState<string>("");
+  const [formFilter, setFormFilter] = useState("");
+  const [forms, setForms] = useState<FormSummary[]>([]);
   const [page, setPage] = useState(0);
   const [selectedId, setSelectedId] = useState<number | null>(null);
   const [detail, setDetail] = useState<RegistrationDetail | null>(null);
@@ -62,14 +73,13 @@ export default function AdminUsers() {
 
   const refresh = async () => {
     setLoading(true);
-    const params = new URLSearchParams({
-      limit: String(PAGE_SIZE),
-      offset: String(page * PAGE_SIZE),
-    });
-    if (statusFilter) params.set("status", statusFilter);
-    if (search.trim()) params.set("q", search.trim());
-
-    const res = await apiFetch(`/api/admin/registrations?${params.toString()}`);
+    const res = await apiFetch(buildAdminRegistrationsPath({
+      limit: PAGE_SIZE,
+      offset: page * PAGE_SIZE,
+      status: statusFilter,
+      search,
+      formKey: formFilter,
+    }));
     if (!res.ok) {
       showToast("Failed to load registrations.", "error");
       setLoading(false);
@@ -85,11 +95,24 @@ export default function AdminUsers() {
   useEffect(() => {
     refresh().catch(() => setLoading(false));
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [statusFilter, page]);
+  }, [statusFilter, formFilter, page]);
+
+  useEffect(() => {
+    apiFetch("/api/admin/form-configs")
+      .then(async (res) => {
+        if (!res.ok) return;
+        const body = await res.json();
+        setForms((body ?? []).map((form: { key: string; title: string }) => ({
+          key: form.key,
+          title: form.title,
+        })));
+      })
+      .catch(() => undefined);
+  }, []);
 
   useEffect(() => {
     setPage(0);
-  }, [statusFilter]);
+  }, [statusFilter, formFilter]);
 
   const filteredRows = useMemo(() => rows, [rows]);
   const totalPages = Math.max(1, Math.ceil(count / PAGE_SIZE));
@@ -116,7 +139,11 @@ export default function AdminUsers() {
   };
 
   const handleExport = async () => {
-    const res = await apiFetch("/api/admin/registrations/export.csv");
+    const res = await apiFetch(buildAdminRegistrationsCsvPath({
+      status: statusFilter,
+      search,
+      formKey: formFilter,
+    }));
     if (!res.ok) {
       showToast("Export failed.", "error");
       return;
@@ -194,6 +221,18 @@ export default function AdminUsers() {
             </option>
           ))}
         </select>
+        <select
+          value={formFilter}
+          onChange={(e) => setFormFilter(e.target.value)}
+          className="rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm font-poppins focus:border-red5 focus:outline-none"
+        >
+          <option value="">All forms</option>
+          {forms.map((form) => (
+            <option key={form.key} value={form.key}>
+              {form.title}
+            </option>
+          ))}
+        </select>
         <button
           onClick={handleExport}
           className="rounded-lg bg-red5 px-4 py-2 text-sm font-poppins font-semibold text-white transition-colors hover:bg-red3"
@@ -212,20 +251,21 @@ export default function AdminUsers() {
                     {column.label}
                   </th>
                 ))}
+                <th className="px-4 py-3 text-left font-semibold">Form</th>
                 <th className="px-4 py-3 text-left font-semibold">Actions</th>
               </tr>
             </thead>
             <tbody>
               {loading && (
                 <tr>
-                  <td colSpan={COLUMNS.length + 1} className="px-4 py-8 text-center text-gray-500">
+                  <td colSpan={COLUMNS.length + 2} className="px-4 py-8 text-center text-gray-500">
                     Loading…
                   </td>
                 </tr>
               )}
               {!loading && filteredRows.length === 0 && (
                 <tr>
-                  <td colSpan={COLUMNS.length + 1} className="px-4 py-8 text-center text-gray-500">
+                  <td colSpan={COLUMNS.length + 2} className="px-4 py-8 text-center text-gray-500">
                     No registrations.
                   </td>
                 </tr>
@@ -245,6 +285,9 @@ export default function AdminUsers() {
                       </td>
                     );
                   })}
+                  <td className="px-4 py-2 text-gray-800">
+                    {row.form_key ?? "registration"}
+                  </td>
                   <td className="px-4 py-2">
                     <div className="flex items-center gap-2">
                       <select
@@ -296,6 +339,9 @@ export default function AdminUsers() {
                     <p className="text-sm font-poppins text-gray-500">{detail.email}</p>
                     <p className="mt-1 text-xs font-poppins text-gray-400">
                       Submitted {new Date(detail.created_at).toLocaleString()}
+                    </p>
+                    <p className="mt-1 text-xs font-poppins text-gray-400">
+                      Form {detail.form_key ?? "registration"} · v{detail.form_version ?? 1}
                     </p>
                   </div>
                   <span className="rounded-full bg-red7 px-3 py-1 text-xs font-poppins font-semibold text-red6">

--- a/frontend/src/pages/admin/adminRegistrationsQuery.test.ts
+++ b/frontend/src/pages/admin/adminRegistrationsQuery.test.ts
@@ -1,0 +1,31 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildAdminRegistrationsCsvPath,
+  buildAdminRegistrationsPath,
+} from "./adminRegistrationsQuery.ts";
+
+test("buildAdminRegistrationsPath includes paging, status, search, and form filters", () => {
+  assert.equal(
+    buildAdminRegistrationsPath({
+      limit: 50,
+      offset: 100,
+      status: "pending",
+      search: "cornell",
+      formKey: "registration",
+    }),
+    "/api/admin/registrations?limit=50&offset=100&status=pending&q=cornell&form_key=registration",
+  );
+});
+
+test("buildAdminRegistrationsCsvPath omits empty filters", () => {
+  assert.equal(
+    buildAdminRegistrationsCsvPath({
+      status: "",
+      search: "  ",
+      formKey: "",
+    }),
+    "/api/admin/registrations/export.csv",
+  );
+});

--- a/frontend/src/pages/admin/adminRegistrationsQuery.ts
+++ b/frontend/src/pages/admin/adminRegistrationsQuery.ts
@@ -1,0 +1,42 @@
+interface AdminRegistrationsQueryOptions {
+  limit?: number;
+  offset?: number;
+  status?: string;
+  search?: string;
+  formKey?: string;
+}
+
+function buildQuery(options: AdminRegistrationsQueryOptions): string {
+  const params = new URLSearchParams();
+
+  if (typeof options.limit === "number") {
+    params.set("limit", String(options.limit));
+  }
+  if (typeof options.offset === "number") {
+    params.set("offset", String(options.offset));
+  }
+  if (options.status?.trim()) {
+    params.set("status", options.status.trim());
+  }
+  if (options.search?.trim()) {
+    params.set("q", options.search.trim());
+  }
+  if (options.formKey?.trim()) {
+    params.set("form_key", options.formKey.trim());
+  }
+
+  const query = params.toString();
+  return query ? `?${query}` : "";
+}
+
+export function buildAdminRegistrationsPath(options: AdminRegistrationsQueryOptions): string {
+  return `/api/admin/registrations${buildQuery(options)}`;
+}
+
+export function buildAdminRegistrationsCsvPath(options: AdminRegistrationsQueryOptions): string {
+  return `/api/admin/registrations/export.csv${buildQuery({
+    status: options.status,
+    search: options.search,
+    formKey: options.formKey,
+  })}`;
+}

--- a/frontend/src/pages/registration/dashboard.tsx
+++ b/frontend/src/pages/registration/dashboard.tsx
@@ -1,16 +1,29 @@
-import { useState, useRef, useEffect } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import RegistrationLayout from "../../components/layouts/RegistrationLayout";
 import { useToast } from "../../components/Toast/ToastContext";
-import ApplicationPanel from "../../components/registration/ApplicationPanel";
+import ApplicationPanel, {
+  type RegistrationResponse as ApplicationRegistration,
+} from "../../components/registration/ApplicationPanel";
 import { supabase } from "../../config/supabase";
 import { apiFetch } from "../../lib/api";
+import {
+  buildApplicationCards,
+  type ActiveFormSummary,
+  type ApplicationCard,
+} from "../../lib/registrationUi";
 import arcade from "@/assets/arcade_device2.png";
 import siteBanner from "@/assets/site_banner.png";
 
-// 9:00 AM Eastern (UTC-4 during EDT) on Oct 2, 2026 — every viewer counts down
-// to the same instant regardless of their local timezone.
 const EVENT_DATE = new Date("2026-10-02T09:00:00-04:00");
+
+interface UserRegistrationSummary {
+  id: number | string;
+  form_key?: string | null;
+  status?: string | null;
+  created_at?: string;
+  updated_at?: string;
+}
 
 function useCountdown(target: Date) {
   const calc = () => {
@@ -56,22 +69,80 @@ const PROFILE_FIELDS: { key: string; label: string }[] = [
 
 function computeCompletion(profile: Record<string, unknown> | null): { pct: number; missing: string[] } {
   if (!profile) return { pct: 0, missing: ["Profile not set up"] };
-  const isEmpty = (v: unknown) =>
-    v === undefined || v === null || v === "" || (Array.isArray(v) && v.length === 0);
-  const missing = PROFILE_FIELDS.filter((f) => isEmpty(profile[f.key])).map((f) => f.label);
+  const isEmpty = (value: unknown) =>
+    value === undefined || value === null || value === "" || (Array.isArray(value) && value.length === 0);
+  const missing = PROFILE_FIELDS.filter((field) => isEmpty(profile[field.key])).map((field) => field.label);
   const pct = Math.round(((PROFILE_FIELDS.length - missing.length) / PROFILE_FIELDS.length) * 100);
   return { pct, missing };
 }
 
 function CountdownUnit({ value, label }: { value: number; label: string }) {
   return (
-    <div className="flex flex-col items-center min-w-[40px]">
-      <span className="text-3xl font-jersey10 text-red6 leading-none tabular-nums">
+    <div className="flex min-w-[40px] flex-col items-center">
+      <span className="tabular-nums text-3xl leading-none text-red6 font-jersey10">
         {String(value).padStart(2, "0")}
       </span>
-      <span className="text-[10px] font-poppins text-gray-400 mt-1 uppercase tracking-wider">{label}</span>
+      <span className="mt-1 text-[10px] uppercase tracking-wider text-gray-400 font-poppins">{label}</span>
     </div>
   );
+}
+
+function getStatusTone(card: ApplicationCard | undefined) {
+  if (!card) {
+    return { dot: "bg-gray-300", badge: "bg-gray-100 text-gray-500" };
+  }
+
+  switch (card.status) {
+    case "approved":
+      return { dot: "bg-green-500", badge: "bg-green-100 text-green-700" };
+    case "rejected":
+      return { dot: "bg-red-400", badge: "bg-red-100 text-red-600" };
+    case "waitlisted":
+      return { dot: "bg-amber-400", badge: "bg-amber-100 text-amber-700" };
+    case "submitted":
+    case "pending":
+      return { dot: "bg-blue-500", badge: "bg-blue-100 text-blue-700" };
+    default:
+      return { dot: card.started ? "bg-blue-500" : "bg-amber-400", badge: "bg-red7 text-red6" };
+  }
+}
+
+function getApplicationSummary(card: ApplicationCard | undefined) {
+  if (!card) {
+    return {
+      headline: "Unavailable",
+      body: "The main registration form is not active right now.",
+    };
+  }
+
+  switch (card.status) {
+    case "approved":
+      return {
+        headline: "Approved",
+        body: "Your application has been approved. Open the form to review what you submitted.",
+      };
+    case "rejected":
+      return {
+        headline: "Rejected",
+        body: "Your application has been reviewed. Open it to confirm the details on file.",
+      };
+    case "waitlisted":
+      return {
+        headline: "Waitlisted",
+        body: "Your application is still in consideration. Open it any time to review your submission.",
+      };
+    case "submitted":
+    case "pending":
+      return {
+        headline: card.stateLabel,
+        body: "Your application is under review. You can still open it to review or update your answers.",
+      };
+    default:
+      return {
+        headline: "Not Started",
+        body: "Complete your profile, then submit your application below.",
+      };
+  }
 }
 
 const Dashboard = () => {
@@ -81,12 +152,12 @@ const Dashboard = () => {
   const countdown = useCountdown(EVENT_DATE);
 
   const [panelOpen, setPanelOpen] = useState(location.pathname === "/register");
-  const [hasApplied, setHasApplied] = useState(false);
   const [profile, setProfile] = useState<Record<string, unknown> | null>(null);
+  const [activeForms, setActiveForms] = useState<ActiveFormSummary[]>([]);
+  const [registrations, setRegistrations] = useState<UserRegistrationSummary[]>([]);
   const { pct, missing } = computeCompletion(profile);
 
-  // Email verification state
-  const [emailVerified, setEmailVerified] = useState<boolean | null>(null); // null = loading
+  const [emailVerified, setEmailVerified] = useState<boolean | null>(null);
   const [userEmail, setUserEmail] = useState<string | null>(null);
   const [resending, setResending] = useState(false);
 
@@ -97,17 +168,23 @@ const Dashboard = () => {
       setEmailVerified(!!user?.email_confirmed_at);
     });
 
-    apiFetch("/api/registrations/me")
-      .then((res) => {
-        if (res.ok) setHasApplied(true);
+    Promise.all([
+      apiFetch("/api/profile"),
+      apiFetch("/api/form-configs"),
+      apiFetch("/api/registrations/me/all"),
+    ])
+      .then(async ([profileRes, formsRes, registrationsRes]) => {
+        if (profileRes.ok) {
+          setProfile(await profileRes.json());
+        }
+        if (formsRes.ok) {
+          setActiveForms(await formsRes.json());
+        }
+        if (registrationsRes.ok) {
+          setRegistrations(await registrationsRes.json());
+        }
       })
-      .catch(() => { /* unauthenticated or network — leave as not started */ });
-
-    apiFetch("/api/profile")
-      .then(async (res) => {
-        if (res.ok) setProfile(await res.json());
-      })
-      .catch(() => { /* leave as null */ });
+      .catch(() => undefined);
   }, []);
 
   useEffect(() => {
@@ -115,6 +192,15 @@ const Dashboard = () => {
       setPanelOpen(true);
     }
   }, [location.pathname]);
+
+  const applicationCards = useMemo(
+    () => buildApplicationCards(activeForms, registrations),
+    [activeForms, registrations],
+  );
+  const registrationCard = applicationCards.find((card) => card.key === "registration");
+  const visibleCards = applicationCards.filter((card) => card.key !== "registration");
+  const registrationSummary = getApplicationSummary(registrationCard);
+  const registrationTone = getStatusTone(registrationCard);
 
   const handlePanelClose = () => {
     setPanelOpen(false);
@@ -135,148 +221,228 @@ const Dashboard = () => {
     }
   };
 
+  const openCard = (card: ApplicationCard) => {
+    if (card.key === "registration") {
+      setPanelOpen(true);
+      return;
+    }
+    navigate(`/forms/${card.key}`);
+  };
+
   return (
     <RegistrationLayout>
       <div className="flex flex-col gap-4 px-2 py-2">
-        <h1 className="text-3xl font-poppins font-bold text-red6 pl-1">Dashboard</h1>
+        <h1 className="pl-1 text-3xl font-bold text-red6 font-poppins">Dashboard</h1>
 
-        {/* Top row: Status + Countdown */}
         <div className="grid grid-cols-2 gap-4">
-
-          {/* Application Status */}
-          <div className="bg-white border border-red7 rounded-xl p-6 flex flex-col gap-3 shadow-sm">
-            <p className="text-[11px] font-poppins font-semibold text-gray-400 uppercase tracking-widest">Application</p>
+          <div className="flex flex-col gap-3 rounded-xl border border-red7 bg-white p-6 shadow-sm">
+            <p className="text-[11px] font-poppins font-semibold uppercase tracking-widest text-gray-400">
+              Application
+            </p>
             <div className="flex items-center gap-2">
-              <span className={`w-2.5 h-2.5 rounded-full ${hasApplied ? "bg-green-500" : "bg-amber-400"}`} />
+              <span className={`h-2.5 w-2.5 rounded-full ${registrationTone.dot}`} />
               <span className="font-poppins font-semibold text-gray-800">
-                {hasApplied ? "Submitted" : "Not Started"}
+                {registrationSummary.headline}
               </span>
             </div>
-            <p className="text-sm font-poppins text-gray-500 leading-relaxed">
-              {hasApplied
-                ? "Your application is under review. We'll be in touch soon."
-                : "Complete your profile, then submit your application below."}
+            <p className="text-sm leading-relaxed text-gray-500 font-poppins">
+              {registrationSummary.body}
             </p>
             <button
-              onClick={() => setPanelOpen(true)}
-              disabled={hasApplied}
-              className="mt-auto w-full py-2 rounded-lg bg-red5 hover:bg-red3 text-white text-sm font-poppins font-semibold transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              onClick={() => registrationCard && setPanelOpen(true)}
+              disabled={!registrationCard}
+              className="mt-auto w-full rounded-lg bg-red5 py-2 text-sm font-poppins font-semibold text-white transition-colors hover:bg-red3 disabled:cursor-not-allowed disabled:opacity-50"
             >
-              {hasApplied ? "Application Submitted ✓" : "Apply Now →"}
+              {registrationCard?.primaryActionLabel ?? "Application Unavailable"}
             </button>
           </div>
 
-          {/* Countdown */}
-          <div className="bg-red7 border border-red7 rounded-xl p-6 flex flex-col gap-3 shadow-sm">
-            <p className="text-[11px] font-poppins font-semibold text-red6 uppercase tracking-widest">BigRed//Hacks FA26</p>
-            <p className="font-poppins text-gray-700 text-sm leading-relaxed">
+          <div className="flex flex-col gap-3 rounded-xl border border-red7 bg-red7 p-6 shadow-sm">
+            <p className="text-[11px] font-poppins font-semibold uppercase tracking-widest text-red6">
+              BigRed//Hacks FA26
+            </p>
+            <p className="text-sm leading-relaxed text-gray-700 font-poppins">
               The largest student-run hackathon @ Cornell University, Ithaca NY.
             </p>
-            <div className="flex items-end gap-3 mt-auto pt-3 border-t border-red5/20">
+            <div className="mt-auto flex items-end gap-3 border-t border-red5/20 pt-3">
               <CountdownUnit value={countdown.days} label="days" />
-              <span className="text-xl font-jersey10 text-red5 mb-4">:</span>
+              <span className="mb-4 text-xl text-red5 font-jersey10">:</span>
               <CountdownUnit value={countdown.hours} label="hrs" />
-              <span className="text-xl font-jersey10 text-red5 mb-4">:</span>
+              <span className="mb-4 text-xl text-red5 font-jersey10">:</span>
               <CountdownUnit value={countdown.minutes} label="min" />
-              <span className="text-xl font-jersey10 text-red5 mb-4">:</span>
+              <span className="mb-4 text-xl text-red5 font-jersey10">:</span>
               <CountdownUnit value={countdown.seconds} label="sec" />
             </div>
           </div>
         </div>
 
-        {/* Email verification — only show if not yet verified */}
         {emailVerified === false && (
-          <div className="bg-white border border-amber-200 rounded-xl px-6 py-4 flex items-center justify-between shadow-sm">
+          <div className="flex items-center justify-between rounded-xl border border-amber-200 bg-white px-6 py-4 shadow-sm">
             <div>
-              <p className="font-poppins font-semibold text-gray-800 text-sm">Verify your email</p>
-              <p className="text-xs font-poppins text-gray-500 mt-0.5">
+              <p className="text-sm font-poppins font-semibold text-gray-800">Verify your email</p>
+              <p className="mt-0.5 text-xs text-gray-500 font-poppins">
                 We sent a link to <span className="font-medium text-gray-700">{userEmail}</span>. Verify to secure your account and receive hackathon updates.
               </p>
             </div>
             <button
               onClick={handleVerifyEmail}
               disabled={resending}
-              className="ml-4 shrink-0 px-5 py-2 bg-red5 hover:bg-red3 text-white text-sm font-poppins font-semibold rounded-lg transition-colors disabled:opacity-60"
+              className="ml-4 shrink-0 rounded-lg bg-red5 px-5 py-2 text-sm font-poppins font-semibold text-white transition-colors hover:bg-red3 disabled:opacity-60"
             >
               {resending ? "Sending…" : "Resend Email"}
             </button>
           </div>
         )}
         {emailVerified === true && (
-          <div className="bg-green-50 border border-green-200 rounded-xl px-6 py-3 flex items-center gap-3 shadow-sm">
-            <span className="text-green-600 font-bold text-lg">✓</span>
-            <p className="font-poppins text-sm text-green-700 font-medium">Email verified — you're all set.</p>
+          <div className="flex items-center gap-3 rounded-xl border border-green-200 bg-green-50 px-6 py-3 shadow-sm">
+            <span className="text-lg font-bold text-green-600">✓</span>
+            <p className="text-sm font-poppins font-medium text-green-700">Email verified — you're all set.</p>
           </div>
         )}
 
-        {/* Profile Completion */}
-        <div className="bg-white border border-red7 rounded-xl p-6 shadow-sm">
-          <div className="flex items-center justify-between mb-3">
+        <div className="rounded-xl border border-red7 bg-white p-6 shadow-sm">
+          <div className="mb-3 flex items-center justify-between">
             <p className="font-poppins font-semibold text-gray-800">Profile Completion</p>
             <span className="text-sm font-poppins font-bold text-red6">{pct}%</span>
           </div>
-          <div className="w-full h-1.5 bg-red7 rounded-full overflow-hidden">
-            <div className="h-full bg-red5 rounded-full transition-all duration-500" style={{ width: `${pct}%` }} />
+          <div className="h-1.5 w-full overflow-hidden rounded-full bg-red7">
+            <div className="h-full rounded-full bg-red5 transition-all duration-500" style={{ width: `${pct}%` }} />
           </div>
           {missing.length > 0 && (
-            <p className="text-xs font-poppins text-gray-400 mt-2">
+            <p className="mt-2 text-xs text-gray-400 font-poppins">
               Missing: {missing.slice(0, 4).join(", ")}{missing.length > 4 ? ` +${missing.length - 4} more` : ""}
             </p>
           )}
           {pct < 100 && (
             <button
               onClick={() => navigate("/profile")}
-              className="mt-2 text-sm font-poppins font-semibold text-red5 hover:text-red6 transition-colors"
+              className="mt-2 text-sm font-poppins font-semibold text-red5 transition-colors hover:text-red6"
             >
               Complete profile →
             </button>
           )}
         </div>
 
-        {/* Site banner / CTA post — click to open registration form */}
+        <div className="rounded-xl border border-red7 bg-white p-6 shadow-sm">
+          <div className="mb-4 flex items-center justify-between gap-3">
+            <div>
+              <p className="text-[11px] font-poppins font-semibold uppercase tracking-widest text-gray-400">
+                Forms & Applications
+              </p>
+              <p className="mt-1 text-sm text-gray-500 font-poppins">
+                Active forms are listed here so you can start, revisit, or update each workflow.
+              </p>
+            </div>
+          </div>
+
+          <div className="grid gap-3 md:grid-cols-2">
+            {applicationCards.length === 0 && (
+              <div className="rounded-lg border border-dashed border-red6/20 bg-red7/20 px-4 py-5">
+                <p className="font-poppins text-sm text-gray-500">No active forms are available right now.</p>
+              </div>
+            )}
+
+            {registrationCard && (
+              <button
+                onClick={() => openCard(registrationCard)}
+                className="flex flex-col items-start gap-3 rounded-lg border border-red6/20 bg-red7/20 px-4 py-5 text-left transition-colors hover:bg-red7/40"
+              >
+                <div className="flex w-full items-center justify-between gap-3">
+                  <p className="font-poppins font-semibold text-gray-900">{registrationCard.title}</p>
+                  <span className={`rounded-full px-3 py-1 text-[11px] font-poppins font-semibold uppercase tracking-widest ${registrationTone.badge}`}>
+                    {registrationCard.stateLabel}
+                  </span>
+                </div>
+                <p className="text-sm text-gray-600 font-poppins">
+                  {registrationCard.description || "Main hackathon application."}
+                </p>
+                <span className="text-sm font-poppins font-semibold text-red5">
+                  {registrationCard.primaryActionLabel} →
+                </span>
+              </button>
+            )}
+
+            {visibleCards.map((card) => {
+              const tone = getStatusTone(card);
+              return (
+                <button
+                  key={card.key}
+                  onClick={() => openCard(card)}
+                  className="flex flex-col items-start gap-3 rounded-lg border border-red6/20 bg-white px-4 py-5 text-left transition-colors hover:bg-red7/20"
+                >
+                  <div className="flex w-full items-center justify-between gap-3">
+                    <p className="font-poppins font-semibold text-gray-900">{card.title}</p>
+                    <span className={`rounded-full px-3 py-1 text-[11px] font-poppins font-semibold uppercase tracking-widest ${tone.badge}`}>
+                      {card.stateLabel}
+                    </span>
+                  </div>
+                  <p className="text-sm text-gray-600 font-poppins">
+                    {card.description || "Additional event workflow."}
+                  </p>
+                  <span className="text-sm font-poppins font-semibold text-red5">
+                    {card.primaryActionLabel} →
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
         <div className="relative group">
-          {/* "post" pole */}
           <div className="flex flex-col items-center">
             <button
-              onClick={() => setPanelOpen(true)}
-              className="relative w-full rounded-xl overflow-hidden shadow-lg cursor-pointer hover-wiggle"
+              onClick={() => registrationCard && setPanelOpen(true)}
+              disabled={!registrationCard}
+              className="relative w-full cursor-pointer overflow-hidden rounded-xl shadow-lg disabled:cursor-not-allowed disabled:opacity-60"
               aria-label="Open application form"
             >
               <img
                 src={siteBanner}
                 alt="BigRed//Hacks — click to apply"
-                className="w-full object-cover rounded-xl"
+                className="w-full rounded-xl object-cover"
               />
-              {/* Hover overlay */}
-              <div className="absolute inset-0 bg-black/0 group-hover:bg-black/20 transition-colors duration-200 flex items-center justify-center rounded-xl">
-                <span className="opacity-0 group-hover:opacity-100 transition-opacity duration-200 bg-red5 text-white font-poppins font-bold text-lg px-8 py-3 rounded-xl shadow-xl">
-                  {hasApplied ? "View Application" : "Apply to BigRed//Hacks →"}
+              <div className="absolute inset-0 flex items-center justify-center rounded-xl bg-black/0 transition-colors duration-200 group-hover:bg-black/20">
+                <span className="rounded-xl bg-red5 px-8 py-3 text-lg font-bold text-white opacity-0 shadow-xl transition-opacity duration-200 group-hover:opacity-100 font-poppins">
+                  {registrationCard ? `${registrationCard.primaryActionLabel} →` : "Application Unavailable"}
                 </span>
               </div>
             </button>
           </div>
         </div>
 
-        {/* Arcade + Hack On */}
-        <div className="bg-red7 rounded-xl flex items-center justify-center gap-8 py-8 px-10 shadow-sm">
+        <div className="flex items-center justify-center gap-8 rounded-xl bg-red7 px-10 py-8 shadow-sm">
           <img src={arcade} alt="arcade machine" className="w-56 drop-shadow-lg" />
-          <p className="text-8xl font-jersey10 text-purple9 leading-tight select-none">
-            Hack<br />On!
+          <p className="select-none text-8xl leading-tight text-purple9 font-jersey10">
+            Hack
+            <br />
+            On!
           </p>
         </div>
-
       </div>
 
       <ApplicationPanel
         isOpen={panelOpen}
         onClose={handlePanelClose}
-        onSubmitted={() => {
-          setHasApplied(true);
+        onSubmitted={(registration: ApplicationRegistration) => {
+          setRegistrations((prev) => {
+            const next = prev.filter((row) => (row.form_key ?? "registration") !== "registration");
+            return [
+              {
+                id: registration.id,
+                form_key: registration.form_key ?? "registration",
+                status: registration.status ?? "pending",
+              },
+              ...next,
+            ];
+          });
           setPanelOpen(false);
           if (location.pathname === "/register") {
             navigate("/dashboard");
           }
-          showToast("Application submitted! We'll be in touch soon.", "success");
+          showToast(
+            registration.status ? `Application ${registration.status}.` : "Application saved.",
+            "success",
+          );
         }}
       />
     </RegistrationLayout>


### PR DESCRIPTION
Close the remaining applicant/admin workflow gaps so the registration site exposes the backend capabilities already in main. This adds active-form discovery, real applicant lifecycle visibility, multi-form review filtering, and modal-based cleanup for the last rough UX flows.

- Add active form discovery and user registration summaries for dashboard state
- Show real application lifecycle status and list active forms on the dashboard
- Surface backend validation errors directly in application and dynamic-form UIs
- Add form filtering and form-scoped CSV export to admin registration review
- Replace prompt and confirm flows for team and admin form actions with in-app modals