### PR TITLE
Host backend as a Netlify Function (frontend + API on one site)

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,0 +1,20 @@
+import express, { Request, Response, NextFunction } from 'express';
+import cors from 'cors';
+import routes from './routes';
+
+const app = express();
+
+// Middleware
+app.use(cors());
+app.use(express.json());
+
+// API routes
+app.use('/api', routes);
+
+// Error handling middleware
+app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+  console.error('Error:', err.message);
+  res.status(500).json({ error: 'Internal server error' });
+});
+
+export default app;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,25 +1,9 @@
 import 'dotenv/config';
-import express, { Request, Response, NextFunction } from 'express';
-import cors from 'cors';
-import routes from './routes';
+import app from './app';
 
-const app = express();
 const PORT = process.env.PORT || 3000;
 
-// Middleware
-app.use(cors());
-app.use(express.json());
-
-// API routes
-app.use('/api', routes);
-
-// Error handling middleware
-app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
-  console.error('Error:', err.message);
-  res.status(500).json({ error: 'Internal server error' });
-});
-
-// Start server
+// Start server (local development / standalone hosting)
 app.listen(PORT, () => {
   console.log(`Server running on http://localhost:${PORT}`);
 });

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,8 +1,22 @@
+# Build from the repo root so npm workspaces install both the frontend and the
+# backend (the backend powers the /api Netlify Function).
 [build]
-  base = "frontend"
-  command = "npm run build"
-  publish = "dist"
+  command = "npm run build:frontend"
+  publish = "frontend/dist"
+  functions = "netlify/functions"
 
+[functions]
+  node_bundler = "esbuild"
+
+# Forward API calls to the Express app running as a Netlify Function. The
+# original /api/... path is preserved, matching the routes in backend/src/app.ts.
+[[redirects]]
+  from = "/api/*"
+  to = "/.netlify/functions/api/:splat"
+  status = 200
+  force = true
+
+# SPA fallback — must come after the /api rule.
 [[redirects]]
   from = "/*"
   to = "/index.html"

--- a/netlify/functions/api.ts
+++ b/netlify/functions/api.ts
@@ -1,0 +1,9 @@
+import 'dotenv/config';
+import serverless from 'serverless-http';
+import type { Handler } from '@netlify/functions';
+import app from '../../backend/src/app';
+
+// Wrap the Express app so it runs as a Netlify Function.
+// The `/api/*` redirect in netlify.toml forwards requests here, preserving the
+// original `/api/...` path, which matches the routes mounted in backend/src/app.ts.
+export const handler: Handler = serverless(app) as unknown as Handler;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,13 @@
       "workspaces": [
         "frontend",
         "backend"
-      ]
+      ],
+      "dependencies": {
+        "serverless-http": "^3.2.0"
+      },
+      "devDependencies": {
+        "@netlify/functions": "^2.8.2"
+      }
     },
     "backend": {
       "name": "brh-registration-backend",
@@ -1019,6 +1025,43 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@netlify/functions": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@netlify/functions/-/functions-2.8.2.tgz",
+      "integrity": "sha512-DeoAQh8LuNPvBE4qsKlezjKj0PyXDryOFJfJKo3Z1qZLKzQ21sT314KQKPVjfvw6knqijj+IO+0kHXy/TJiqNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@netlify/serverless-functions-api": "1.26.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@netlify/node-cookies": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@netlify/node-cookies/-/node-cookies-0.1.0.tgz",
+      "integrity": "sha512-OAs1xG+FfLX0LoRASpqzVntVV/RpYkgpI0VrUnw2u0Q1qiZUzcPffxRK8HF3gc4GjuhG5ahOEMJ9bswBiZPq0g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.16.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@netlify/serverless-functions-api": {
+      "version": "1.26.1",
+      "resolved": "https://registry.npmjs.org/@netlify/serverless-functions-api/-/serverless-functions-api-1.26.1.tgz",
+      "integrity": "sha512-q3L9i3HoNfz0SGpTIS4zTcKBbRkxzCRpd169eyiTuk3IwcPC3/85mzLHranlKo2b+HYT0gu37YxGB45aD8A3Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@netlify/node-cookies": "^0.1.0",
+        "urlpattern-polyfill": "8.0.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@react-email/render": {
@@ -4771,6 +4814,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/serverless-http": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/serverless-http/-/serverless-http-3.2.0.tgz",
+      "integrity": "sha512-QvSyZXljRLIGqwcJ4xsKJXwkZnAVkse1OajepxfjkBXV0BMvRS5R546Z4kCBI8IygDzkQY0foNPC/rnipaE9pQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
     "node_modules/set-cookie-parser": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
@@ -5187,6 +5239,13 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/urlpattern-polyfill": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-8.0.2.tgz",
+      "integrity": "sha512-Qp95D4TPJl1kC9SKigDcqgyM2VDVO4RiJc2d4qe5GrYm+zbIQCWWKAFaJNQ4BhdFeDGwBmAxqJBwWSJDb9T3BQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -15,5 +15,11 @@
     "dev": "npm run dev:frontend & npm run dev:backend",
     "build": "npm run build:frontend && npm run build:backend",
     "lint": "npm run lint -w frontend"
+  },
+  "dependencies": {
+    "serverless-http": "^3.2.0"
+  },
+  "devDependencies": {
+    "@netlify/functions": "^2.8.2"
   }
 }


### PR DESCRIPTION
## What
Wires the Express backend up so the whole app (frontend + API) is served from the single Netlify site connected to this repo, with autodeploy from \`main\`.

- Extracts the Express app into \`backend/src/app.ts\` (shared by local dev server and the serverless handler).
- Adds \`netlify/functions/api.ts\` wrapping the app with \`serverless-http\`.
- \`netlify.toml\`: builds from the repo root via npm workspaces (so backend deps install), routes \`/api/*\` to the function ahead of the SPA fallback.

## Env
Supabase env vars (\`VITE_*\` for the build, \`SUPABASE_*\` for the function) are set in Netlify site settings. \`RESEND_API_KEY\` is not set yet — confirmation emails are skipped gracefully until it is.

## Verify
Netlify deploy preview for this PR should: load the SPA, and respond on \`/api/*\` (e.g. \`/api/profile\` requires auth → 401 rather than the SPA HTML).

🤖 Generated with [Claude Code](https://claude.com/claude-code)