### PR TITLE
Fix invisible profile save block + unusable country field

### DIFF
--- a/frontend/src/components/SearchableCombobox.tsx
+++ b/frontend/src/components/SearchableCombobox.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect, useMemo } from "react";
 import { loadCsvOptions, type CsvType } from "@/lib/loadCsvOptions";
+import { resolveComboboxCommit } from "@/lib/combobox";
 
 interface SearchableComboboxProps {
   value: string;
@@ -35,6 +36,11 @@ export default function SearchableCombobox({
     loadCsvOptions(csvUrl, csvType).then(setCsvOptions).catch(() => {});
   }, [csvUrl, csvType]);
 
+  const allOptions = useMemo(
+    () => [...new Set([...csvOptions, ...staticOptions])],
+    [csvOptions, staticOptions]
+  );
+
   // Close on outside pointer-down. Using a document listener (instead of a
   // full-viewport backdrop) so wheel events reach the surrounding scroll
   // container instead of falling through to the page body.
@@ -43,18 +49,21 @@ export default function SearchableCombobox({
     const handlePointerDown = (e: MouseEvent) => {
       if (!containerRef.current?.contains(e.target as Node)) {
         setOpen(false);
-        if (allowCustomValue && inputText.trim()) onChange(inputText.trim());
-        else setInputText(value);
+        // Commit a typed value that resolves to a real option (or any value
+        // when custom input is allowed); otherwise revert the text. This keeps
+        // a typed-but-not-clicked entry from being silently dropped.
+        const committed = resolveComboboxCommit(inputText, allOptions, allowCustomValue);
+        if (committed !== null) {
+          onChange(committed);
+          setInputText(committed);
+        } else {
+          setInputText(value);
+        }
       }
     };
     document.addEventListener("mousedown", handlePointerDown);
     return () => document.removeEventListener("mousedown", handlePointerDown);
-  }, [open, allowCustomValue, inputText, value, onChange]);
-
-  const allOptions = useMemo(
-    () => [...new Set([...csvOptions, ...staticOptions])],
-    [csvOptions, staticOptions]
-  );
+  }, [open, allowCustomValue, inputText, value, onChange, allOptions]);
 
   const filtered = useMemo(() => {
     if (!query.trim()) return allOptions.slice(0, 100);

--- a/frontend/src/lib/combobox.test.ts
+++ b/frontend/src/lib/combobox.test.ts
@@ -1,0 +1,31 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { resolveComboboxCommit } from "./combobox.ts";
+
+const countries = ["United States of America", "United Kingdom", "Canada"];
+
+test("commits an exact (case-insensitive) match even when custom values are disallowed", () => {
+  assert.equal(
+    resolveComboboxCommit("united states of america", countries, false),
+    "United States of America"
+  );
+});
+
+test("keeps the current value (null) when text is not a known option and custom is disallowed", () => {
+  // Regression: a typed-but-unmatched value must never be silently turned into junk.
+  assert.equal(resolveComboboxCommit("usa", countries, false), null);
+});
+
+test("commits arbitrary trimmed text when custom values are allowed", () => {
+  assert.equal(resolveComboboxCommit("  My Custom School  ", [], true), "My Custom School");
+});
+
+test("canonicalizes casing to the known option when custom values are allowed", () => {
+  assert.equal(resolveComboboxCommit("canada", countries, true), "Canada");
+});
+
+test("empty / whitespace input never commits", () => {
+  assert.equal(resolveComboboxCommit("   ", countries, true), null);
+  assert.equal(resolveComboboxCommit("", countries, false), null);
+});

--- a/frontend/src/lib/combobox.ts
+++ b/frontend/src/lib/combobox.ts
@@ -1,0 +1,29 @@
+/**
+ * Decide what a searchable combobox should commit when focus leaves the field
+ * (outside click / blur), given the text the user typed.
+ *
+ * Returns the value to commit via `onChange`, or `null` to leave the current
+ * value unchanged.
+ *
+ * Rules:
+ *  - Empty/whitespace input commits nothing (keep the current value).
+ *  - If the text matches a known option (case-insensitively), commit the
+ *    canonical option — even when custom values are disallowed. This prevents
+ *    silently discarding a perfectly valid value the user typed instead of
+ *    clicking (the bug that made the "Country of Residence" field unusable).
+ *  - Otherwise, commit the trimmed text only when custom values are allowed;
+ *    if not, keep the current value (the user must pick a real option).
+ */
+export function resolveComboboxCommit(
+  inputText: string,
+  options: string[],
+  allowCustomValue: boolean
+): string | null {
+  const trimmed = inputText.trim();
+  if (!trimmed) return null;
+
+  const exact = options.find((o) => o.toLowerCase() === trimmed.toLowerCase());
+  if (exact) return exact;
+
+  return allowCustomValue ? trimmed : null;
+}

--- a/frontend/src/lib/formConfig.ts
+++ b/frontend/src/lib/formConfig.ts
@@ -229,6 +229,25 @@ export const LEVEL_OF_STUDY_OPTIONS = [
 ] as const;
 
 // ---------------------------------------------------------------------------
+// Sanitizers for values loaded from the server. Option sets evolve over time
+// (and test/legacy rows exist), so a stored value may no longer be a valid
+// enum member. These drop/blank unknown values on load so the form stays
+// editable and saveable instead of failing validation against a value the UI
+// can't even display.
+// ---------------------------------------------------------------------------
+
+/** Keep only array values that are part of the allowed option set. */
+export function keepKnownOptions(values: unknown, allowed: readonly string[]): string[] {
+  if (!Array.isArray(values)) return [];
+  return values.filter((v): v is string => typeof v === "string" && allowed.includes(v));
+}
+
+/** Return the value if it's a known option, otherwise "" (renders as unselected). */
+export function coerceKnownOption(value: unknown, allowed: readonly string[]): string {
+  return typeof value === "string" && allowed.includes(value) ? value : "";
+}
+
+// ---------------------------------------------------------------------------
 // Form configurations
 // ---------------------------------------------------------------------------
 
@@ -467,6 +486,7 @@ export const hackathonRegistrationFormConfig: FormConfig = {
       type: "dropdown",
       required: true,
       searchable: true,
+      allowCustomValue: true,
       options: [],
       optionsSource: {
         type: "csv",

--- a/frontend/src/lib/optionSanitize.test.ts
+++ b/frontend/src/lib/optionSanitize.test.ts
@@ -1,0 +1,55 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  keepKnownOptions,
+  coerceKnownOption,
+  profileSchema,
+  AGE_RANGES,
+  DIETARY_OPTIONS,
+  GENDER_OPTIONS,
+} from "./formConfig.ts";
+
+test("keepKnownOptions drops values outside the allowed set", () => {
+  assert.deepEqual(keepKnownOptions(["Vegan", "Test"], DIETARY_OPTIONS), ["Vegan"]);
+  assert.deepEqual(keepKnownOptions(["Vegan", 5, null], DIETARY_OPTIONS), ["Vegan"]);
+  assert.deepEqual(keepKnownOptions(null, DIETARY_OPTIONS), []);
+  assert.deepEqual(keepKnownOptions(undefined, DIETARY_OPTIONS), []);
+});
+
+test("coerceKnownOption blanks unknown single values", () => {
+  assert.equal(coerceKnownOption("Male", GENDER_OPTIONS), "Male");
+  assert.equal(coerceKnownOption("not-a-gender", GENDER_OPTIONS), "");
+  assert.equal(coerceKnownOption(null, GENDER_OPTIONS), "");
+});
+
+function baseValidProfile(overrides: Record<string, unknown>) {
+  return {
+    firstName: "Richie",
+    lastName: "Xue",
+    email: "rx77@cornell.edu",
+    phoneNumber: "(347) 579-5414",
+    age: AGE_RANGES[1],
+    graduationYear: "2028",
+    university: "Cornell University",
+    country: "",
+    levelOfStudy: "",
+    major: "",
+    gender: "Male",
+    dietaryRestrictions: [] as string[],
+    shirtSize: "L",
+    linkedin: "",
+    ...overrides,
+  };
+}
+
+test("regression: a legacy dietary value blocks the profile save invisibly", () => {
+  // Exactly the data found in the DB for this user.
+  const raw = baseValidProfile({ dietaryRestrictions: ["Vegan", "Test"] });
+  assert.equal(profileSchema.safeParse(raw).success, false);
+
+  const fixed = baseValidProfile({
+    dietaryRestrictions: keepKnownOptions(["Vegan", "Test"], DIETARY_OPTIONS),
+  });
+  assert.equal(profileSchema.safeParse(fixed).success, true);
+});

--- a/frontend/src/pages/registration/profile.tsx
+++ b/frontend/src/pages/registration/profile.tsx
@@ -5,9 +5,11 @@ import { supabase } from "../../config/supabase";
 import SearchableCombobox from "../../components/SearchableCombobox";
 import {
   AGE_RANGES,
+  coerceKnownOption,
   COUNTRIES_CSV_URL,
   DIETARY_OPTIONS,
   GENDER_OPTIONS,
+  keepKnownOptions,
   LEVEL_OF_STUDY_OPTIONS,
   MAJOR_SUGGESTIONS,
   profileSchema,
@@ -97,18 +99,21 @@ const Profile = () => {
           firstName: profile.first_name ?? prev.firstName,
           lastName: profile.last_name ?? prev.lastName,
           phoneNumber: profile.phone_number ?? prev.phoneNumber,
-          age: profile.age_range ?? prev.age,
+          // Enum-constrained fields: drop/blank values that are no longer valid
+          // options (e.g. legacy or test data) so they don't invisibly fail
+          // validation against choices the UI can't display.
+          age: coerceKnownOption(profile.age_range, AGE_RANGES) || prev.age,
           graduationYear:
             profile.graduation_year != null ? String(profile.graduation_year) : prev.graduationYear,
           university: profile.school ?? prev.university,
           country: profile.country ?? prev.country,
-          levelOfStudy: profile.level_of_study ?? prev.levelOfStudy,
+          levelOfStudy: coerceKnownOption(profile.level_of_study, LEVEL_OF_STUDY_OPTIONS),
           major: profile.major ?? prev.major,
-          gender: profile.gender ?? prev.gender,
+          gender: coerceKnownOption(profile.gender, GENDER_OPTIONS),
           dietaryRestrictions: Array.isArray(profile.dietary_restrictions)
-            ? profile.dietary_restrictions
+            ? keepKnownOptions(profile.dietary_restrictions, DIETARY_OPTIONS)
             : prev.dietaryRestrictions,
-          shirtSize: profile.shirt_size ?? prev.shirtSize,
+          shirtSize: coerceKnownOption(profile.shirt_size, SHIRT_SIZES),
           linkedin: profile.linkedin ?? prev.linkedin,
         }));
       })
@@ -329,7 +334,7 @@ const Profile = () => {
               />
             </Field>
 
-            <Field label="Major / Field of Study">
+            <Field label="Major / Field of Study" error={errors.major}>
               <SearchableCombobox
                 value={form.major}
                 onChange={(v) => handleChange("major", v)}
@@ -376,7 +381,7 @@ const Profile = () => {
             {/* Preferences */}
             <SectionHeader title="Preferences" />
 
-            <Field label="Gender">
+            <Field label="Gender" error={errors.gender}>
               <div className="relative">
                 <select
                   value={form.gender}
@@ -391,7 +396,7 @@ const Profile = () => {
             </Field>
 
             <div className="col-span-2">
-              <Field label="Dietary Restrictions / Allergies">
+              <Field label="Dietary Restrictions / Allergies" error={errors.dietaryRestrictions}>
                 <div className="flex flex-wrap items-center gap-x-5 gap-y-2 mt-1">
                   {DIETARY_OPTIONS.map((option) => {
                     const checked = form.dietaryRestrictions.includes(option);
@@ -428,7 +433,7 @@ const Profile = () => {
             </div>
 
             <div className="col-span-full">
-              <Field label="Shirt Size (US sizing)">
+              <Field label="Shirt Size (US sizing)" error={errors.shirtSize}>
                 <div className="flex items-center gap-6 mt-1">
                   {SHIRT_SIZES.map((size) => {
                     const selected = form.shirtSize === size;


### PR DESCRIPTION
## Bugs fixed

### 1. Profile: \"Please fix the highlighted fields\" with nothing highlighted
A stored \`dietary_restrictions\` value not in \`DIETARY_OPTIONS\` (legacy/test data, e.g. \`\"Test\"\`) failed the client Zod enum. But the dietary/gender/shirt fields rendered **no** error message, and the invalid value had no checkbox to uncheck — so the toast fired with nothing visible and **every save silently failed**.

- Sanitize enum-constrained fields on load: \`keepKnownOptions\` (arrays) / \`coerceKnownOption\` (single) drop values the UI can't display.
- Render errors on the dietary, gender, shirt, and major fields so this can't be invisible again.

### 2. \"Country of Residence\" wouldn't let you submit
In the application form the field had \`allowCustomValue: false\` while the placeholder says \"Search or type…\", so a typed value was discarded unless you clicked a dropdown row → permanent \"required\".

- \`SearchableCombobox\` now commits a typed value that resolves to a real option (case-canonicalized) even when custom values are disallowed (no more silent data loss).
- The country field allows custom values, matching the profile page's country field (which already worked).

## Tests
\`node:test\` coverage for \`resolveComboboxCommit\` and the option sanitizers — including the exact \`[\"Vegan\",\"Test\"]\` row that caused the bug. All 16 frontend tests pass; build + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)