### PR TITLE
Admin row selection + un-clip combobox dropdown

### DIFF
--- a/frontend/src/components/SearchableCombobox.tsx
+++ b/frontend/src/components/SearchableCombobox.tsx
@@ -1,4 +1,5 @@
-import { useState, useRef, useEffect, useMemo } from "react";
+import { useState, useRef, useEffect, useMemo, useCallback, useLayoutEffect } from "react";
+import { createPortal } from "react-dom";
 import { loadCsvOptions, type CsvType } from "@/lib/loadCsvOptions";
 import { resolveComboboxCommit } from "@/lib/combobox";
 
@@ -27,9 +28,11 @@ export default function SearchableCombobox({
   const [inputText, setInputText] = useState(value);
   const [query, setQuery] = useState("");
   const [csvOptions, setCsvOptions] = useState<string[]>([]);
+  const [menuRect, setMenuRect] = useState<{ top: number; left: number; width: number } | null>(null);
   const focused = useRef(false);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!csvUrl) return;
@@ -41,24 +44,46 @@ export default function SearchableCombobox({
     [csvOptions, staticOptions]
   );
 
-  // Close on outside pointer-down. Using a document listener (instead of a
-  // full-viewport backdrop) so wheel events reach the surrounding scroll
-  // container instead of falling through to the page body.
+  // Position the dropdown in a fixed-position portal so it isn't clipped by an
+  // ancestor scroll container (e.g. the application form panel). Reposition on
+  // scroll/resize while it's open.
+  const updateMenuRect = useCallback(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const r = el.getBoundingClientRect();
+    setMenuRect({ top: r.bottom + 4, left: r.left, width: r.width });
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!open) return;
+    updateMenuRect();
+    window.addEventListener("scroll", updateMenuRect, true);
+    window.addEventListener("resize", updateMenuRect);
+    return () => {
+      window.removeEventListener("scroll", updateMenuRect, true);
+      window.removeEventListener("resize", updateMenuRect);
+    };
+  }, [open, updateMenuRect]);
+
+  // Close on outside pointer-down. Clicks inside the input wrapper or the
+  // (portaled) dropdown count as inside.
   useEffect(() => {
     if (!open) return;
     const handlePointerDown = (e: MouseEvent) => {
-      if (!containerRef.current?.contains(e.target as Node)) {
-        setOpen(false);
-        // Commit a typed value that resolves to a real option (or any value
-        // when custom input is allowed); otherwise revert the text. This keeps
-        // a typed-but-not-clicked entry from being silently dropped.
-        const committed = resolveComboboxCommit(inputText, allOptions, allowCustomValue);
-        if (committed !== null) {
-          onChange(committed);
-          setInputText(committed);
-        } else {
-          setInputText(value);
-        }
+      const target = e.target as Node;
+      if (containerRef.current?.contains(target) || dropdownRef.current?.contains(target)) {
+        return;
+      }
+      setOpen(false);
+      // Commit a typed value that resolves to a real option (or any value
+      // when custom input is allowed); otherwise revert the text. This keeps
+      // a typed-but-not-clicked entry from being silently dropped.
+      const committed = resolveComboboxCommit(inputText, allOptions, allowCustomValue);
+      if (committed !== null) {
+        onChange(committed);
+        setInputText(committed);
+      } else {
+        setInputText(value);
       }
     };
     document.addEventListener("mousedown", handlePointerDown);
@@ -109,22 +134,34 @@ export default function SearchableCombobox({
         autoComplete="off"
         className="w-full bg-white border border-gray-200 rounded-lg px-3 py-2.5 text-sm text-gray-800 placeholder-gray-400 focus:outline-none focus:border-red5 transition-colors font-poppins"
       />
-      {open && filtered.length > 0 && (
-        <div className="absolute z-10 top-full mt-1 w-full bg-white border border-gray-200 rounded-lg shadow-lg max-h-52 overflow-y-auto overscroll-contain [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:bg-gray-200 [&::-webkit-scrollbar-thumb]:rounded-full">
-          {filtered.map((opt) => (
-            <button
-              key={opt}
-              type="button"
-              onMouseDown={(e) => { e.preventDefault(); select(opt); }}
-              className={`w-full px-3 py-2 text-left text-sm font-poppins text-gray-800 hover:bg-red7 transition-colors ${
-                opt === value ? "bg-red7 font-medium text-red6" : ""
-              }`}
-            >
-              {opt}
-            </button>
-          ))}
-        </div>
-      )}
+      {open && filtered.length > 0 && menuRect &&
+        createPortal(
+          <div
+            ref={dropdownRef}
+            style={{
+              position: "fixed",
+              top: menuRect.top,
+              left: menuRect.left,
+              width: menuRect.width,
+              zIndex: 1000,
+            }}
+            className="bg-white border border-gray-200 rounded-lg shadow-lg max-h-52 overflow-y-auto overscroll-contain [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:bg-gray-200 [&::-webkit-scrollbar-thumb]:rounded-full"
+          >
+            {filtered.map((opt) => (
+              <button
+                key={opt}
+                type="button"
+                onMouseDown={(e) => { e.preventDefault(); select(opt); }}
+                className={`w-full px-3 py-2 text-left text-sm font-poppins text-gray-800 hover:bg-red7 transition-colors ${
+                  opt === value ? "bg-red7 font-medium text-red6" : ""
+                }`}
+              >
+                {opt}
+              </button>
+            ))}
+          </div>,
+          document.body
+        )}
     </div>
   );
 }

--- a/frontend/src/pages/admin/AdminUsers.tsx
+++ b/frontend/src/pages/admin/AdminUsers.tsx
@@ -242,7 +242,7 @@ export default function AdminUsers() {
       </div>
 
       <div className="grid grid-cols-[minmax(0,1fr)_420px] gap-4">
-        <div className="overflow-hidden rounded-lg border border-red6/20 bg-white">
+        <div className="overflow-x-auto rounded-lg border border-red6/20 bg-white">
           <table className="w-full text-sm font-poppins">
             <thead className="bg-red7 text-red6">
               <tr>
@@ -273,7 +273,8 @@ export default function AdminUsers() {
               {!loading && filteredRows.map((row) => (
                 <tr
                   key={row.id}
-                  className={`border-t border-red6/10 hover:bg-red7/40 ${
+                  onClick={() => loadDetail(row.id)}
+                  className={`cursor-pointer border-t border-red6/10 hover:bg-red7/40 ${
                     selectedId === row.id ? "bg-red7/60" : ""
                   }`}
                 >
@@ -292,7 +293,11 @@ export default function AdminUsers() {
                     <div className="flex items-center gap-2">
                       <select
                         value={row.status}
-                        onChange={(e) => handleStatusChange(row.id, e.target.value)}
+                        onClick={(e) => e.stopPropagation()}
+                        onChange={(e) => {
+                          e.stopPropagation();
+                          handleStatusChange(row.id, e.target.value);
+                        }}
                         className="rounded border border-gray-200 bg-white px-2 py-1 text-xs focus:border-red5 focus:outline-none"
                       >
                         {STATUS_OPTIONS.map((status) => (
@@ -302,7 +307,10 @@ export default function AdminUsers() {
                         ))}
                       </select>
                       <button
-                        onClick={() => loadDetail(row.id)}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          loadDetail(row.id);
+                        }}
                         className="rounded border border-red5 px-2 py-1 text-xs font-semibold text-red5 transition-colors hover:bg-red5 hover:text-white"
                       >
                         Review


### PR DESCRIPTION
## Bugs fixed

### 1. Can't open a submission in the admin table
The detail panel only loaded via a **Review** button in the rightmost **Actions** column, which was clipped off-screen (`overflow-hidden` table wrapper beside the fixed 420px detail panel), and rows had no click handler — so there was no reachable way to inspect a registration.

- Rows are now clickable → load the detail panel ("click a submission to view it").
- Table wrapper is `overflow-x-auto` so the status control / Actions are reachable.
- Inline status `select` and Review button `stopPropagation` so they don't also trigger row selection.

### 2. Can't pick a country (unless pre-filled from profile)
`SearchableCombobox`'s dropdown was absolutely positioned **inside** the application form's `overflow-y-auto` scroll container (ApplicationPanel), so the options list was clipped and unclickable.

- The dropdown now renders in a **fixed-position portal** appended to `document.body`, escaping the scroll container, and repositions on scroll/resize.
- Outside-click detection updated to treat clicks in the portaled dropdown as "inside".

## Tests / build
All 16 frontend `node:test` tests pass; typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)