### PR TITLE
Flip global default text color to dark (light-only color-scheme)

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -48,8 +48,11 @@
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
+  /* Light-only app: force native controls (selects, inputs) to render light so
+     OS dark mode can't re-theme them, and default text to a readable dark gray
+     (gray-800) so any element that doesn't set its own color stays visible. */
+  color-scheme: light;
+  color: #1f2937;
   background-color: #ffffff; /* white prevents dark flash on registration page overscroll */
 
   font-synthesis: none;


### PR DESCRIPTION
## Why
`:root` defaulted text to **white** (`rgba(255,255,255,0.87)`, a leftover from the Vite starter template). Any element that forgot to set its own color rendered white-on-white — the admin filter controls were one symptom. This is a footgun for every future control.

## Audit
Checked every dark-background region for text relying on inherited white:
- **Sidebar** — every link sets `text-white`/`text-red5`; only the logo image is uncolored.
- **Auth pages / ProtectedRoute** (red gradient) — content lives in colored cards; "Loading…" sets `text-white`.
- **Toast** (`bg-[#1a1a1a]`), **team-matching** buttons (`bg-[#e46966]`), **modals**, **landing gradient** — all set explicit text colors.

Conclusion: nothing relies on inheriting white, so flipping the default is safe and *fixes* latent invisible-text bugs rather than creating new ones.

## Change
- `:root` color → `#1f2937` (gray-800, matches the app's body text).
- `color-scheme: light dark` → `light` (light-only app; stops OS dark mode from re-theming native selects/inputs).

Verified with screenshots of login, dashboard+sidebar, admin, and the application form on the deploy preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)