### PR TITLE
Application form: note type, Box-resume swap, custom school entry, status-bug fix

### DIFF
--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -251,7 +251,7 @@ router.get(
 const FormFieldSchema = z.object({
   id: z.string().min(1),
   label: z.string().min(1),
-  type: z.enum(['text', 'email', 'dropdown', 'radio', 'checkbox', 'checkboxGroup', 'file', 'multipleChoiceGrid', 'preferenceGrid']),
+  type: z.enum(['text', 'email', 'dropdown', 'radio', 'checkbox', 'checkboxGroup', 'file', 'multipleChoiceGrid', 'preferenceGrid', 'note']),
   required: z.boolean(),
   description: z.string().optional(),
   placeholder: z.string().optional(),

--- a/backend/src/routes/registrations.ts
+++ b/backend/src/routes/registrations.ts
@@ -247,7 +247,7 @@ router.get('/me/all', async (req: Request, res: Response) => {
   try {
     const { data, error } = await supabase
       .from('registrations')
-      .select('id, form_key, form_version, status, created_at, updated_at, resume_path')
+      .select('id, form_key, form_version, status, created_at, resume_path')
       .eq('user_id', req.user!.id)
       .order('created_at', { ascending: false });
 

--- a/backend/src/utils/registrationForms.ts
+++ b/backend/src/utils/registrationForms.ts
@@ -9,7 +9,8 @@ export type DynamicFormFieldType =
   | 'checkboxGroup'
   | 'file'
   | 'multipleChoiceGrid'
-  | 'preferenceGrid';
+  | 'preferenceGrid'
+  | 'note';
 
 interface BaseDynamicFormField {
   id: string;
@@ -23,6 +24,7 @@ export type DynamicFormField =
   | (BaseDynamicFormField & { type: 'checkbox' })
   | (BaseDynamicFormField & { type: 'checkboxGroup' })
   | (BaseDynamicFormField & { type: 'file' })
+  | (BaseDynamicFormField & { type: 'note' })
   | (BaseDynamicFormField & {
       type: 'multipleChoiceGrid' | 'preferenceGrid';
       rows: string[];
@@ -54,6 +56,11 @@ export function buildAnswersSchema(fields: DynamicFormField[]) {
   const shape: Record<string, z.ZodTypeAny> = {};
 
   for (const field of fields) {
+    // Display-only fields carry no answer and aren't validated.
+    if (field.type === 'note') {
+      continue;
+    }
+
     switch (field.type) {
       case 'text':
       case 'dropdown':

--- a/frontend/src/components/SearchableCombobox.tsx
+++ b/frontend/src/components/SearchableCombobox.tsx
@@ -122,6 +122,15 @@ export default function SearchableCombobox({
 
   const displayValue = focused.current || open ? inputText : value;
 
+  // Offer an explicit "Use '<typed>'" row when custom values are allowed and the
+  // text isn't an existing option, so users (e.g. with a school not in the list)
+  // can see their entry will be accepted instead of relying on a silent commit.
+  const trimmedInput = inputText.trim();
+  const showAddCustom =
+    allowCustomValue &&
+    trimmedInput.length > 0 &&
+    !allOptions.some((o) => o.toLowerCase() === trimmedInput.toLowerCase());
+
   return (
     <div ref={containerRef} className={`relative ${className}`}>
       <input
@@ -134,7 +143,7 @@ export default function SearchableCombobox({
         autoComplete="off"
         className="w-full bg-white border border-gray-200 rounded-lg px-3 py-2.5 text-sm text-gray-800 placeholder-gray-400 focus:outline-none focus:border-red5 transition-colors font-poppins"
       />
-      {open && filtered.length > 0 && menuRect &&
+      {open && (filtered.length > 0 || showAddCustom) && menuRect &&
         createPortal(
           <div
             ref={dropdownRef}
@@ -159,6 +168,16 @@ export default function SearchableCombobox({
                 {opt}
               </button>
             ))}
+            {showAddCustom && (
+              <button
+                key="__add_custom__"
+                type="button"
+                onMouseDown={(e) => { e.preventDefault(); select(trimmedInput); }}
+                className="w-full border-t border-gray-100 px-3 py-2 text-left text-sm font-poppins text-red6 hover:bg-red7 transition-colors"
+              >
+                Use "{trimmedInput}"
+              </button>
+            )}
           </div>,
           document.body
         )}

--- a/frontend/src/components/registration/ApplicationPanel.tsx
+++ b/frontend/src/components/registration/ApplicationPanel.tsx
@@ -68,32 +68,6 @@ function formatStatusLabel(status?: string | null): string {
   return `${status.charAt(0).toUpperCase()}${status.slice(1)}`;
 }
 
-async function uploadResume(file: File): Promise<string> {
-  const urlRes = await apiFetch(`/api/registrations/me/resume-upload-url?form_key=${FORM_KEY}`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ filename: file.name }),
-  });
-  if (!urlRes.ok) throw new Error("Could not get upload URL");
-  const { signedUrl, path } = await urlRes.json();
-
-  if (!signedUrl) throw new Error("Storage upload URL missing");
-  const putRes = await fetch(signedUrl, {
-    method: "PUT",
-    headers: { "Content-Type": file.type || "application/pdf" },
-    body: file,
-  });
-  if (!putRes.ok) throw new Error("Storage upload failed");
-
-  const persistRes = await apiFetch(`/api/registrations/me/resume?form_key=${FORM_KEY}`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ resume_path: path }),
-  });
-  if (!persistRes.ok) throw new Error("Could not save resume reference");
-  return path;
-}
-
 export default function ApplicationPanel({ isOpen, onClose, onSubmitted }: ApplicationPanelProps) {
   const { showToast } = useToast();
   const [isLoading, setIsLoading] = useState(false);
@@ -101,8 +75,6 @@ export default function ApplicationPanel({ isOpen, onClose, onSubmitted }: Appli
   const [isSubmitted, setIsSubmitted] = useState(false);
   const [prefillBannerDismissed, setPrefillBannerDismissed] = useState(false);
   const [initialValues, setInitialValues] = useState<Record<string, unknown>>({});
-  const [resumeFile, setResumeFile] = useState<File | null>(null);
-  const [existingResumePath, setExistingResumePath] = useState<string | null>(null);
   const [hasExistingSubmission, setHasExistingSubmission] = useState(false);
   const [submissionMode, setSubmissionMode] = useState<"created" | "updated">("created");
   const [config, setConfig] = useState<FormConfig | null>(null);
@@ -119,7 +91,6 @@ export default function ApplicationPanel({ isOpen, onClose, onSubmitted }: Appli
     const loadPanelState = async () => {
       setIsBootstrapping(true);
       setIsSubmitted(false);
-      setResumeFile(null);
       setSubmissionErrors({});
 
       try {
@@ -154,7 +125,6 @@ export default function ApplicationPanel({ isOpen, onClose, onSubmitted }: Appli
           setHasExistingSubmission(true);
           setSubmissionMode("updated");
           setInitialValues(registrationToFormValues(registration));
-          setExistingResumePath(registration.resume_path ?? null);
           setCurrentStatus(registration.status ?? null);
           setPrefillBannerDismissed(true);
           return;
@@ -164,7 +134,6 @@ export default function ApplicationPanel({ isOpen, onClose, onSubmitted }: Appli
           setHasExistingSubmission(false);
           setSubmissionMode("created");
           setInitialValues({});
-          setExistingResumePath(null);
           setCurrentStatus(null);
           setPrefillBannerDismissed(false);
         }
@@ -172,7 +141,6 @@ export default function ApplicationPanel({ isOpen, onClose, onSubmitted }: Appli
         if (!cancelled) {
           setHasExistingSubmission(false);
           setSubmissionMode("created");
-          setExistingResumePath(null);
           setCurrentStatus(null);
         }
       } finally {
@@ -236,48 +204,19 @@ export default function ApplicationPanel({ isOpen, onClose, onSubmitted }: Appli
       }
 
       const savedRegistration = (await res.json()) as RegistrationResponse;
-      let nextResumePath = savedRegistration.resume_path ?? existingResumePath;
-
-      if (resumeFile) {
-        try {
-          nextResumePath = await uploadResume(resumeFile);
-        } catch {
-          showToast("Application submitted, but resume upload failed. You can upload it later.", "info");
-        }
-      }
 
       setSubmissionMode(hasExistingSubmission ? "updated" : "created");
       setHasExistingSubmission(true);
-      setExistingResumePath(nextResumePath);
       setInitialValues(registrationToFormValues(savedRegistration));
       setCurrentStatus(savedRegistration.status ?? null);
       setIsSubmitted(true);
-      onSubmitted({
-        ...savedRegistration,
-        resume_path: nextResumePath,
-      });
+      onSubmitted(savedRegistration);
     } catch (error) {
       console.error(error);
       showToast(error instanceof Error ? error.message : "Failed to submit application. Please try again.", "error");
     } finally {
       setIsLoading(false);
     }
-  };
-
-  const handleResumeDownload = async () => {
-    const res = await apiFetch(`/api/registrations/me/resume-download-url?form_key=${FORM_KEY}`);
-    if (!res.ok) {
-      showToast("Could not get the uploaded resume.", "error");
-      return;
-    }
-
-    const body = await res.json();
-    if (!body.signedUrl) {
-      showToast("Uploaded resume is unavailable right now.", "error");
-      return;
-    }
-
-    window.open(body.signedUrl, "_blank", "noopener,noreferrer");
   };
 
   return (
@@ -381,51 +320,15 @@ export default function ApplicationPanel({ isOpen, onClose, onSubmitted }: Appli
               </button>
             </div>
           ) : (
-            <>
-              <div className="mb-5 bg-red7 border border-red5/20 rounded-xl px-5 py-4">
-                <div className="flex items-start justify-between gap-4">
-                  <div>
-                    <label className="font-poppins text-sm font-semibold text-gray-800 block mb-2">
-                      Resume (optional)
-                    </label>
-                    <input
-                      type="file"
-                      accept=".pdf,.doc,.docx"
-                      onChange={(e) => setResumeFile(e.target.files?.[0] ?? null)}
-                      className="text-sm font-poppins text-gray-700"
-                    />
-                  </div>
-                  {existingResumePath && (
-                    <button
-                      type="button"
-                      onClick={handleResumeDownload}
-                      className="shrink-0 rounded-lg border border-red5 px-3 py-2 text-xs font-poppins font-semibold text-red5 transition-colors hover:bg-white"
-                    >
-                      View Uploaded Resume
-                    </button>
-                  )}
-                </div>
-                {resumeFile && (
-                  <p className="mt-1 text-xs font-poppins text-gray-500">
-                    Selected: {resumeFile.name}
-                  </p>
-                )}
-                {!resumeFile && existingResumePath && (
-                  <p className="mt-1 text-xs font-poppins text-gray-500">
-                    A resume is already on file. Upload a new file to replace it.
-                  </p>
-                )}
-              </div>
-              <DynamicForm
-                config={config}
-                onSubmit={handleSubmit}
-                isLoading={isLoading}
-                initialValues={initialValues}
-                hideHeader
-                submissionErrors={submissionErrors}
-                submitLabel={hasExistingSubmission ? "Update Application" : "Submit Application"}
-              />
-            </>
+            <DynamicForm
+              config={config}
+              onSubmit={handleSubmit}
+              isLoading={isLoading}
+              initialValues={initialValues}
+              hideHeader
+              submissionErrors={submissionErrors}
+              submitLabel={hasExistingSubmission ? "Update Application" : "Submit Application"}
+            />
           )}
         </div>
       </div>

--- a/frontend/src/components/registration/DynamicForm.tsx
+++ b/frontend/src/components/registration/DynamicForm.tsx
@@ -8,6 +8,7 @@ import CheckboxGroup from "./form-fields/CheckboxGroup";
 import FileUpload from "./form-fields/FileUpload";
 import MultipleChoiceGrid from "./form-fields/MultipleChoiceGrid";
 import PreferenceGrid from "./form-fields/PreferenceGrid";
+import Note from "./form-fields/Note";
 
 interface DynamicFormProps {
   config: FormConfig;
@@ -183,6 +184,9 @@ export default function DynamicForm({
             onChange={(value) => handleFieldChange(field.id, value)}
           />
         );
+
+      case "note":
+        return <Note field={field} />;
 
       default:
         return null;

--- a/frontend/src/components/registration/form-fields/Note.tsx
+++ b/frontend/src/components/registration/form-fields/Note.tsx
@@ -1,0 +1,18 @@
+import type { NoteFormField } from "@/lib/formConfig";
+
+interface NoteProps {
+  field: NoteFormField;
+}
+
+// Display-only informational note. Renders the label as a bold notice with an
+// optional description below. No input, no value.
+export default function Note({ field }: NoteProps) {
+  return (
+    <div className="w-full rounded-lg border border-red5/30 bg-red7 px-6 py-4">
+      <p className="font-poppins text-sm font-bold text-red6">{field.label}</p>
+      {field.description && (
+        <p className="mt-1 font-poppins text-sm text-gray-700">{field.description}</p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/lib/buildSchema.test.ts
+++ b/frontend/src/lib/buildSchema.test.ts
@@ -1,0 +1,42 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { buildSchemaFromFields } from "./buildSchema.ts";
+import type { FormField } from "./formConfig.ts";
+
+test("note fields are display-only: skipped by the schema, never required", () => {
+  const fields: FormField[] = [
+    { id: "travel_note", type: "note", label: "No travel reimbursement this year", required: false },
+    { id: "first_name", type: "text", label: "First Name", required: true },
+    {
+      id: "resume_uploaded",
+      type: "checkbox",
+      label: "Resume",
+      required: true,
+      checkboxText: "I uploaded my resume to the",
+    },
+  ];
+  const schema = buildSchemaFromFields(fields);
+
+  // Valid: no value supplied for the note, required fields satisfied.
+  assert.equal(
+    schema.safeParse({ first_name: "Richie", resume_uploaded: true }).success,
+    true,
+  );
+  // Required checkbox must be checked.
+  assert.equal(
+    schema.safeParse({ first_name: "Richie", resume_uploaded: false }).success,
+    false,
+  );
+  // Required text must be present.
+  assert.equal(schema.safeParse({ resume_uploaded: true }).success, false);
+});
+
+test("optional text fields (e.g. dietary_other) accept empty/missing values", () => {
+  const schema = buildSchemaFromFields([
+    { id: "dietary_other", type: "text", label: "Other dietary restriction", required: false },
+  ]);
+  assert.equal(schema.safeParse({}).success, true);
+  assert.equal(schema.safeParse({ dietary_other: "" }).success, true);
+  assert.equal(schema.safeParse({ dietary_other: "no eggs" }).success, true);
+});

--- a/frontend/src/lib/buildSchema.ts
+++ b/frontend/src/lib/buildSchema.ts
@@ -29,6 +29,9 @@ export function buildSchemaFromFields(fields: FormField[]): z.ZodType {
   const shape: Record<string, z.ZodTypeAny> = {};
 
   for (const field of fields) {
+    // Display-only fields contribute no value and aren't validated.
+    if (field.type === "note") continue;
+
     let s: z.ZodTypeAny;
 
     switch (field.type) {

--- a/frontend/src/lib/formConfig.ts
+++ b/frontend/src/lib/formConfig.ts
@@ -10,7 +10,8 @@ export type FormFieldType =
   | "checkboxGroup"
   | "file"
   | "multipleChoiceGrid"
-  | "preferenceGrid";
+  | "preferenceGrid"
+  | "note";
 
 export interface BaseFormField {
   id: string;
@@ -79,6 +80,12 @@ export interface PreferenceGridFormField extends BaseFormField {
   columns: string[];
 }
 
+// Display-only informational note. Renders bold text (from label) plus optional
+// description; contributes no value and is skipped by the validation schema.
+export interface NoteFormField extends BaseFormField {
+  type: "note";
+}
+
 export type FormField =
   | TextFormField
   | EmailFormField
@@ -88,7 +95,8 @@ export type FormField =
   | CheckboxGroupFormField
   | FileFormField
   | MultipleChoiceGridFormField
-  | PreferenceGridFormField;
+  | PreferenceGridFormField
+  | NoteFormField;
 
 export interface FormConfig {
   title: string;


### PR DESCRIPTION
Code changes supporting the requested application updates (the actual form-content changes — "Other" text fields, resume checkbox, travel note — are applied as `form_configs` data after this merges, since a `note` field would break the current production code).

### Changes
- **`note` field type** — display-only bold notice, config-driven. Skipped by frontend `buildSchemaFromFields` and backend `buildAnswersSchema` (never requires a value); whitelisted in the admin form-config schema.
- **Remove in-app resume uploader** (`ApplicationPanel.tsx`) — resumes will be collected via a required Box-folder checkbox in the form config.
- **SearchableCombobox `Use "<typed>"` option** — when custom values are allowed and the text isn't an existing option, show an explicit commit row so applicants whose school isn't listed can clearly enter it.
- **Fix `GET /api/registrations/me/all`** — it selected a non-existent `registrations.updated_at` column, so the endpoint **500'd for everyone** → the dashboard showed every submitted application as **"Not Started"**. Dropped the column. (Root cause confirmed live against the real schema.)

### Tests / build
Added `buildSchema.test.ts` (note skipped, optional text accepted). 18 frontend tests pass; frontend build + backend `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)