### PR TITLE
Add note type to admin form editor type list

### DIFF
--- a/frontend/src/pages/admin/AdminFormEditor.tsx
+++ b/frontend/src/pages/admin/AdminFormEditor.tsx
@@ -22,6 +22,7 @@ const TYPE_OPTIONS: { value: FormFieldType; label: string }[] = [
   { value: "checkboxGroup", label: "Multi-select" },
   { value: "multipleChoiceGrid", label: "Multiple Choice Grid" },
   { value: "preferenceGrid", label: "Preference Grid" },
+  { value: "note", label: "Note (display only)" },
 ];
 
 const TYPES_WITH_OPTIONS: FormFieldType[] = ["dropdown", "radio", "checkboxGroup"];


### PR DESCRIPTION
Small follow-up to PR #24: adds the display-only **Note** field type to the admin form editor's type dropdown so admins can see/select it (the type is already supported everywhere else).

🤖 Generated with [Claude Code](https://claude.com/claude-code)